### PR TITLE
Feature implementation from commits df8d80f..536a5f2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install tox
       - name: Run Tests
         run: tox -e py
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install tox
       - name: Run Tests
         run: tox -e py
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -31,7 +31,7 @@ SKIP_LABEL_STATUS = create_status(
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
-(https://devguide.python.org/core-developers/committing/index.html#updating-news-and-what-s-new-in-python). \
+(https://devguide.python.org/core-developers/committing/#updating-news-and-what-s-new-in-python). \
 Add one using the [blurb_it]({BLURB_IT_URL}) web app or \
 the [blurb]({BLURB_PYPI_URL}) command-line tool.
 

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -31,7 +31,7 @@ SKIP_LABEL_STATUS = create_status(
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
-(https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python). \
+(https://devguide.python.org/core-developers/committing/index.html#updating-news-and-what-s-new-in-python). \
 Add one using the [blurb_it]({BLURB_IT_URL}) web app or \
 the [blurb]({BLURB_PYPI_URL}) command-line tool.
 

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -45,7 +45,7 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         filepath = pathlib.PurePath(filename)
         if filepath.suffix == ".rst" or filepath.name == ".nitignore":
             docs = True
-        elif filepath.name.startswith("test_"):
+        elif filepath.name.startswith(("test_", "_test")):
             tests = True
         else:
             return pr_labels

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 asynctest==0.13.0
 pytest==7.4.4
-pytest-asyncio==0.23.2
+pytest-asyncio==0.23.4
 pytest-aiohttp==1.0.5
 pytest-cov==4.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 asynctest==0.13.0
-pytest==8.0.0
+pytest==8.0.2
 pytest-asyncio==0.23.5
 pytest-aiohttp==1.0.5
 pytest-cov==4.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 asynctest==0.13.0
-pytest==7.4.4
-pytest-asyncio==0.23.4
+pytest==8.0.0
+pytest-asyncio==0.23.5
 pytest-aiohttp==1.0.5
 pytest-cov==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
 yarl==1.9.4
-sentry-sdk==1.39.1
+sentry-sdk==1.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
 yarl==1.9.4
-sentry-sdk==1.40.0
+sentry-sdk==1.40.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ async-timeout==4.0.3
 cachetools==5.3.2
 chardet==5.2.0
 gidgethub==5.3.0
-multidict==6.0.4
+multidict==6.0.5
 packaging==23.2
 pyparsing==3.1.1
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.2
+aiohttp==3.9.3
 appdirs==1.4.4
 async-timeout==4.0.3
 cachetools==5.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.9.3
 appdirs==1.4.4
 async-timeout==4.0.3
-cachetools==5.3.2
+cachetools==5.3.3
 chardet==5.2.0
 gidgethub==5.3.0
 multidict==6.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ packaging==23.2
 pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
-yarl==1.9.3
+yarl==1.9.4
 sentry-sdk==1.39.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.1
+aiohttp==3.9.2
 appdirs==1.4.4
 async-timeout==4.0.3
 cachetools==5.3.2

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -145,6 +145,26 @@ async def test_tests_only():
     assert gh.post_data[0] == [Labels.tests.value]
 
 
+async def test_tests_and_testmods_only():
+    filenames = {"/path/to/_testmod.c", "_test_module.c", "test_capi,py"}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
+    gh = FakeGH(getitem=issue)
+    event_data = {
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+        },
+    }
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
+    assert len(gh.post_url) == 1
+    assert gh.post_url[0] == "https://api.github.com/some/label"
+    assert gh.post_data[0] == [Labels.tests.value]
+
+
 async def test_docs_and_tests():
     filenames = {"/path/to/docs.rst", "test_docs2.py"}
     issue = {


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `df8d80f..536a5f2`
**Files Changed:** 5 (3 programming files)
**Programming Ratio:** 60.0%

**Commits included:**
- Bump cachetools from 5.3.2 to 5.3.3 (#627)
- Bump sentry-sdk from 1.40.0 to 1.40.6 (#628)
- Bump pytest from 8.0.0 to 8.0.2 (#629)
- Bump multidict from 6.0.4 to 6.0.5 (#630)
- Remove unnecessary `index.html` from link. (#626)
- Update redirected link (#625)
- Bump pytest from 7.4.4 to 8.0.0 (#619)
- Revert "Bump codecov/codecov-action from 3 to 4 (#623)" (#624)
- Bump codecov/codecov-action from 3 to 4 (#623)
- Bump pytest-asyncio from 0.23.2 to 0.23.4 (#621)
... and 5 more commits