### PR TITLE
Feature implementation from commits d354adb..a5ec2ba

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+35235fd609a52db835beb2a96d0da461a0eab3ed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        files: \.py$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-builtin-literals
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: forbid-new-submodules
+      - id: trailing-whitespace

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,30 +46,30 @@ Heroku admins can do it too.
 #. Install Heroku CLI
 
    Details at: https://devcenter.heroku.com/articles/heroku-cli
-  
+
 #. Login to Heroku CLI on the command line and follow instructions::
-      
+
       heroku login
-   
-  
+
+
 #. If you haven't already, get a clone of the bedevere repo::
-     
+
       git clone git@github.com:python/bedevere.git
-  
+
    Or, using `GitHub CLI`_::
-   
-      gh repo clone python/bedevere 
+
+      gh repo clone python/bedevere
 
 #. From the ``bedevere`` directory, add the ``bedevere`` Heroku app as remote branch::
-   
+
       heroku git:remote -a bedevere
-  
- 
+
+
 #. From the ``bedevere`` directory, push to Heroku::
-  
+
       git push heroku main
-  
-  
+
+
 After a successful push, the deployment will begin.
 
 Heroku app collaborators and members

--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -5,36 +5,38 @@ import sys
 import traceback
 
 import aiohttp
-from aiohttp import web
 import cachetools
-from gidgethub import aiohttp as gh_aiohttp
-from gidgethub import routing
-from gidgethub import sansio
-from gidgethub import apps
-
-from . import backport, gh_issue, close_pr, filepaths, news, stage
-
 import sentry_sdk
+from aiohttp import web
+from gidgethub import aiohttp as gh_aiohttp
+from gidgethub import apps, routing, sansio
 
-router = routing.Router(backport.router, gh_issue.router, close_pr.router,
-                        filepaths.router, news.router,
-                        stage.router)
+from . import backport, close_pr, filepaths, gh_issue, news, stage
+
+router = routing.Router(
+    backport.router,
+    gh_issue.router,
+    close_pr.router,
+    filepaths.router,
+    news.router,
+    stage.router,
+)
 cache = cachetools.LRUCache(maxsize=500)
 
 sentry_sdk.init(os.environ.get("SENTRY_DSN"))
+
 
 async def main(request):
     try:
         body = await request.read()
         secret = os.environ.get("GH_SECRET")
         event = sansio.Event.from_http(request.headers, body, secret=secret)
-        print('GH delivery ID', event.delivery_id, file=sys.stderr)
+        print("GH delivery ID", event.delivery_id, file=sys.stderr)
         if event.event == "ping":
             return web.Response(status=200)
 
         async with aiohttp.ClientSession() as session:
-            gh = gh_aiohttp.GitHubAPI(session, "python/bedevere",
-                                      cache=cache)
+            gh = gh_aiohttp.GitHubAPI(session, "python/bedevere", cache=cache)
 
             if event.data.get("installation"):
                 # This path only works on GitHub App
@@ -43,14 +45,14 @@ async def main(request):
                     gh,
                     installation_id=installation_id,
                     app_id=os.environ.get("GH_APP_ID"),
-                    private_key=os.environ.get("GH_PRIVATE_KEY")
+                    private_key=os.environ.get("GH_PRIVATE_KEY"),
                 )
                 gh.oauth_token = installation_access_token["token"]
             # Give GitHub some time to reach internal consistency.
             await asyncio.sleep(1)
             await router.dispatch(event, gh, session=session)
         try:
-            print('GH requests remaining:', gh.rate_limit.remaining)
+            print("GH requests remaining:", gh.rate_limit.remaining)
         except AttributeError:
             pass
         return web.Response(status=200)
@@ -62,7 +64,9 @@ async def main(request):
 @router.register("installation", action="created")
 async def repo_installation_added(event, gh, *args, **kwargs):
     # installation_id = event.data["installation"]["id"]
-    print(f"App installed by {event.data['installation']['account']['login']}, installation_id: {event.data['installation']['id']}")
+    print(
+        f"App installed by {event.data['installation']['account']['login']}, installation_id: {event.data['installation']['id']}"
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -15,6 +15,8 @@ from gidgethub import apps
 from . import backport, gh_issue, close_pr, filepaths, news, stage
 
 import sentry_sdk
+import logging
+
 
 router = routing.Router(backport.router, gh_issue.router, close_pr.router,
                         filepaths.router, news.router,
@@ -24,6 +26,7 @@ cache = cachetools.LRUCache(maxsize=500)
 sentry_sdk.init(os.environ.get("SENTRY_DSN"))
 
 async def main(request):
+    logging.basicConfig(level=logging.DEBUG)
     try:
         body = await request.read()
         secret = os.environ.get("GH_SECRET")

--- a/bedevere/__main__.py
+++ b/bedevere/__main__.py
@@ -15,8 +15,6 @@ from gidgethub import apps
 from . import backport, gh_issue, close_pr, filepaths, news, stage
 
 import sentry_sdk
-import logging
-
 
 router = routing.Router(backport.router, gh_issue.router, close_pr.router,
                         filepaths.router, news.router,
@@ -26,7 +24,6 @@ cache = cachetools.LRUCache(maxsize=500)
 sentry_sdk.init(os.environ.get("SENTRY_DSN"))
 
 async def main(request):
-    logging.basicConfig(level=logging.DEBUG)
     try:
         body = await request.read()
         secret = os.environ.get("GH_SECRET")

--- a/bedevere/backport.py
+++ b/bedevere/backport.py
@@ -6,27 +6,35 @@ import gidgethub.routing
 
 from . import util
 
-create_status = functools.partial(util.create_status, 'bedevere/maintenance-branch-pr')
+create_status = functools.partial(util.create_status, "bedevere/maintenance-branch-pr")
 
 
 router = gidgethub.routing.Router()
 
-TITLE_RE = re.compile(r'\s*\[(?P<branch>\d+\.\d+)\].+\((?:GH-|#)(?P<pr>\d+)\)', re.IGNORECASE)
-MAINTENANCE_BRANCH_TITLE_RE = re.compile(r'\s*\[(?P<branch>\d+\.\d+)\].+')
-MAINTENANCE_BRANCH_RE = re.compile(r'\s*(?P<branch>\d+\.\d+)')
-BACKPORT_LABEL = 'needs backport to {branch}'
-MESSAGE_TEMPLATE = ('[GH-{pr}](https://github.com/python/cpython/pull/{pr}) is '
-                    'a backport of this pull request to the '
-                    '[{branch} branch](https://github.com/python/cpython/tree/{branch}).')
+TITLE_RE = re.compile(
+    r"\s*\[(?P<branch>\d+\.\d+)\].+\((?:GH-|#)(?P<pr>\d+)\)", re.IGNORECASE
+)
+MAINTENANCE_BRANCH_TITLE_RE = re.compile(r"\s*\[(?P<branch>\d+\.\d+)\].+")
+MAINTENANCE_BRANCH_RE = re.compile(r"\s*(?P<branch>\d+\.\d+)")
+BACKPORT_LABEL = "needs backport to {branch}"
+MESSAGE_TEMPLATE = (
+    "[GH-{pr}](https://github.com/python/cpython/pull/{pr}) is "
+    "a backport of this pull request to the "
+    "[{branch} branch](https://github.com/python/cpython/tree/{branch})."
+)
 
 
-BACKPORT_TITLE_DEVGUIDE_URL = "https://devguide.python.org/committing/#backport-pr-title"
+BACKPORT_TITLE_DEVGUIDE_URL = (
+    "https://devguide.python.org/committing/#backport-pr-title"
+)
+
 
 async def _copy_over_labels(gh, original_issue, backport_issue):
     """Copy over relevant labels from the original PR to the backport PR."""
     label_prefixes = "skip", "type", "sprint"
-    labels = list(filter(lambda x: x.startswith(label_prefixes),
-                    util.labels(original_issue)))
+    labels = list(
+        filter(lambda x: x.startswith(label_prefixes), util.labels(original_issue))
+    )
     if labels:
         await gh.post(backport_issue["labels_url"], data=labels)
 
@@ -38,10 +46,10 @@ async def _remove_backport_label(gh, original_issue, branch, backport_pr_number)
     """
     backport_label = BACKPORT_LABEL.format(branch=branch)
     message = MESSAGE_TEMPLATE.format(branch=branch, pr=backport_pr_number)
-    await gh.post(original_issue['comments_url'], data={'body': message})
+    await gh.post(original_issue["comments_url"], data={"body": message})
     if backport_label not in util.labels(original_issue):
         return
-    await gh.delete(original_issue['labels_url'], {'name': backport_label})
+    await gh.delete(original_issue["labels_url"], {"name": backport_label})
 
 
 @router.register("pull_request", action="opened")
@@ -50,18 +58,17 @@ async def manage_labels(event, gh, *args, **kwargs):
     if event.data["action"] == "edited" and "title" not in event.data["changes"]:
         return
     pull_request = event.data["pull_request"]
-    title = util.normalize_title(pull_request['title'],
-                                 pull_request['body'])
+    title = util.normalize_title(pull_request["title"], pull_request["body"])
     title_match = TITLE_RE.match(title)
     if title_match is None:
         return
-    branch = title_match.group('branch')
-    original_pr_number = title_match.group('pr')
+    branch = title_match.group("branch")
+    original_pr_number = title_match.group("pr")
 
-    original_issue = await gh.getitem(event.data['repository']['issues_url'],
-                                      {'number': original_pr_number})
-    await _remove_backport_label(gh, original_issue, branch,
-                                 event.data["number"])
+    original_issue = await gh.getitem(
+        event.data["repository"]["issues_url"], {"number": original_pr_number}
+    )
+    await _remove_backport_label(gh, original_issue, branch, event.data["number"])
 
     backport_issue = await util.issue_for_PR(gh, pull_request)
     await _copy_over_labels(gh, original_issue, backport_issue)
@@ -78,7 +85,7 @@ def is_maintenance_branch(ref):
     >>> is_maintenance_branch("gh-1234/something-completely-different")
     False
     """
-    maintenance_branch_pattern = r'\d+\.\d+'
+    maintenance_branch_pattern = r"\d+\.\d+"
     return bool(re.fullmatch(maintenance_branch_pattern, ref))
 
 
@@ -102,17 +109,19 @@ async def validate_maintenance_branch_pr(event, gh, *args, **kwargs):
     if not is_maintenance_branch(base_branch):
         return
 
-    title = util.normalize_title(pull_request["title"],
-                                 pull_request["body"])
+    title = util.normalize_title(pull_request["title"], pull_request["body"])
     title_match = MAINTENANCE_BRANCH_TITLE_RE.match(title)
 
     if title_match is None:
-        status = create_status(util.StatusState.FAILURE,
-                               description="Not a valid maintenance branch PR title.",
-                               target_url=BACKPORT_TITLE_DEVGUIDE_URL)
+        status = create_status(
+            util.StatusState.FAILURE,
+            description="Not a valid maintenance branch PR title.",
+            target_url=BACKPORT_TITLE_DEVGUIDE_URL,
+        )
     else:
-        status = create_status(util.StatusState.SUCCESS,
-                               description="Valid maintenance branch PR title.")
+        status = create_status(
+            util.StatusState.SUCCESS, description="Valid maintenance branch PR title."
+        )
     await util.post_status(gh, event, status)
 
 
@@ -130,6 +139,9 @@ async def maintenance_branch_created(event, gh, *args, **kwargs):
     if MAINTENANCE_BRANCH_RE.match(branch_name):
         await gh.post(
             "/repos/python/cpython/labels",
-            data={"name": f"needs backport to {branch_name}", "color": "c2e0c6",
-                  "description": "bug and security fixes"},
+            data={
+                "name": f"needs backport to {branch_name}",
+                "color": "c2e0c6",
+                "description": "bug and security fixes",
+            },
         )

--- a/bedevere/close_pr.py
+++ b/bedevere/close_pr.py
@@ -3,8 +3,7 @@ import re
 
 import gidgethub.routing
 
-
-PYTHON_MAINT_BRANCH_RE = re.compile(r'^\w+:\d+\.\d+$')
+PYTHON_MAINT_BRANCH_RE = re.compile(r"^\w+:\d+\.\d+$")
 
 INVALID_PR_COMMENT = """\
 PRs attempting to merge a maintenance branch into the \
@@ -15,6 +14,7 @@ see devguide.python.org for further instruction as needed."""
 
 
 router = gidgethub.routing.Router()
+
 
 @router.register("pull_request", action="opened")
 @router.register("pull_request", action="synchronize")
@@ -28,17 +28,15 @@ async def close_invalid_pr(event, gh, *args, **kwargs):
     head_label = event.data["pull_request"]["head"]["label"]
     base_label = event.data["pull_request"]["base"]["label"]
 
-    if PYTHON_MAINT_BRANCH_RE.match(head_label) and \
-        base_label == "python:main":
-        data = {'state': 'closed'}
+    if PYTHON_MAINT_BRANCH_RE.match(head_label) and base_label == "python:main":
+        data = {"state": "closed"}
         await gh.patch(event.data["pull_request"]["url"], data=data)
         await gh.post(
-            f'{event.data["pull_request"]["issue_url"]}/labels',
-            data=["invalid"]
+            f'{event.data["pull_request"]["issue_url"]}/labels', data=["invalid"]
         )
         await gh.post(
             f'{event.data["pull_request"]["issue_url"]}/comments',
-            data={'body': INVALID_PR_COMMENT}
+            data={"body": INVALID_PR_COMMENT},
         )
 
 
@@ -53,10 +51,16 @@ async def dismiss_invalid_pr_review_request(event, gh, *args, **kwargs):
     head_label = event.data["pull_request"]["head"]["label"]
     base_label = event.data["pull_request"]["base"]["label"]
 
-    if PYTHON_MAINT_BRANCH_RE.match(head_label) and \
-            base_label == "python:main":
-        data = {"reviewers": [reviewer["login"] for reviewer in event.data["pull_request"]["requested_reviewers"]],
-                "team_reviewers": [team["name"] for team in event.data["pull_request"]["requested_teams"]]
-                }
-        await gh.delete(f'{event.data["pull_request"]["url"]}/requested_reviewers',
-                        data=data)
+    if PYTHON_MAINT_BRANCH_RE.match(head_label) and base_label == "python:main":
+        data = {
+            "reviewers": [
+                reviewer["login"]
+                for reviewer in event.data["pull_request"]["requested_reviewers"]
+            ],
+            "team_reviewers": [
+                team["name"] for team in event.data["pull_request"]["requested_teams"]
+            ],
+        }
+        await gh.delete(
+            f'{event.data["pull_request"]["url"]}/requested_reviewers', data=data
+        )

--- a/bedevere/filepaths.py
+++ b/bedevere/filepaths.py
@@ -1,22 +1,19 @@
 """Checks related to filepaths on a pull request."""
 import gidgethub.routing
 
-from . import news
-from . import prtype
-from . import util
-
+from . import news, prtype, util
 
 router = gidgethub.routing.Router()
 
 
-@router.register('pull_request', action='opened')
-@router.register('pull_request', action='synchronize')
-@router.register('pull_request', action='reopened')
+@router.register("pull_request", action="opened")
+@router.register("pull_request", action="synchronize")
+@router.register("pull_request", action="reopened")
 async def check_file_paths(event, gh, *args, **kwargs):
-    pull_request = event.data['pull_request']
+    pull_request = event.data["pull_request"]
     files = await util.files_for_PR(gh, pull_request)
-    filenames = [file['file_name'] for file in files]
-    if event.data['action'] == 'opened':
+    filenames = [file["file_name"] for file in files]
+    if event.data["action"] == "opened":
         labels = await prtype.classify_by_filepaths(gh, pull_request, filenames)
         if prtype.Labels.skip_news not in labels:
             await news.check_news(gh, pull_request, files)

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -7,25 +7,27 @@ import gidgethub.routing
 
 from . import util
 
-
 router = gidgethub.routing.Router()
 
 
-create_status = functools.partial(util.create_status, 'bedevere/news')
+create_status = functools.partial(util.create_status, "bedevere/news")
 
-BLURB_IT_URL = 'https://blurb-it.herokuapp.com'
-BLURB_PYPI_URL = 'https://pypi.org/project/blurb/'
+BLURB_IT_URL = "https://blurb-it.herokuapp.com"
+BLURB_PYPI_URL = "https://pypi.org/project/blurb/"
 
-FILENAME_RE = re.compile(r"""# YYYY-mm-dd or YYYY-mm-dd-HH-MM-SS
+FILENAME_RE = re.compile(
+    r"""# YYYY-mm-dd or YYYY-mm-dd-HH-MM-SS
                              \d{4}-\d{2}-\d{2}(?:-\d{2}-\d{2}-\d{2})?\.
                              (?:bpo|gh-issue)-\d+(?:,\d+)*\. # Issue number(s)
                              [A-Za-z0-9_=-]+\.         # Nonce (URL-safe base64)
                              rst                       # File extension""",
-                         re.VERBOSE)
+    re.VERBOSE,
+)
 
 SKIP_NEWS_LABEL = util.skip_label("news")
-SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
-                                  description='"skip news" label found')
+SKIP_LABEL_STATUS = create_status(
+    util.StatusState.SUCCESS, description='"skip news" label found'
+)
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
@@ -47,39 +49,45 @@ async def check_news(gh, pull_request, files=None):
         files = await util.files_for_PR(gh, pull_request)
     in_next_dir = file_found = False
     for file in files:
-        if not util.is_news_dir(file['file_name']):
+        if not util.is_news_dir(file["file_name"]):
             continue
         in_next_dir = True
-        file_path = pathlib.PurePath(file['file_name'])
+        file_path = pathlib.PurePath(file["file_name"])
         if len(file_path.parts) != 5:  # Misc, NEWS.d, next, <subsection>, <entry>
             continue
         file_found = True
-        if FILENAME_RE.match(file_path.name) and len(file['patch']) >= 1:
-            status = create_status(util.StatusState.SUCCESS,
-                                   description='News entry found in Misc/NEWS.d')
+        if FILENAME_RE.match(file_path.name) and len(file["patch"]) >= 1:
+            status = create_status(
+                util.StatusState.SUCCESS, description="News entry found in Misc/NEWS.d"
+            )
             break
     else:
         issue = await util.issue_for_PR(gh, pull_request)
         if util.skip("news", issue):
             status = SKIP_LABEL_STATUS
         else:
-            if pull_request['author_association'] == 'NONE':
-                await gh.post(f"{pull_request['issue_url']}/comments",
-                              data={'body': HELP})
+            if pull_request["author_association"] == "NONE":
+                await gh.post(
+                    f"{pull_request['issue_url']}/comments", data={"body": HELP}
+                )
             if not in_next_dir:
-                description = f'No news entry in {util.NEWS_NEXT_DIR} or "skip news" label found'
+                description = (
+                    f'No news entry in {util.NEWS_NEXT_DIR} or "skip news" label found'
+                )
             elif not file_found:
                 description = "News entry not in an appropriate directory"
             else:
                 description = "News entry file name incorrectly formatted"
-            status = create_status(util.StatusState.FAILURE,
-                                   description=description,
-                                   target_url=BLURB_IT_URL)
+            status = create_status(
+                util.StatusState.FAILURE,
+                description=description,
+                target_url=BLURB_IT_URL,
+            )
 
-    await gh.post(pull_request['statuses_url'], data=status)
+    await gh.post(pull_request["statuses_url"], data=status)
 
 
-@router.register('pull_request', action="labeled")
+@router.register("pull_request", action="labeled")
 async def label_added(event, gh, *args, **kwargs):
     if util.label_name(event.data) == SKIP_NEWS_LABEL:
         await util.post_status(gh, event, SKIP_LABEL_STATUS)
@@ -90,5 +98,5 @@ async def label_removed(event, gh, *args, **kwargs):
     if util.no_labels(event.data):
         return
     elif util.label_name(event.data) == SKIP_NEWS_LABEL:
-        pull_request = event.data['pull_request']
+        pull_request = event.data["pull_request"]
         await check_news(gh, pull_request)

--- a/bedevere/news.py
+++ b/bedevere/news.py
@@ -29,10 +29,13 @@ SKIP_LABEL_STATUS = create_status(util.StatusState.SUCCESS,
 
 HELP = f"""\
 Most changes to Python [require a NEWS entry]\
-(https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python).
+(https://devguide.python.org/committing/#updating-news-and-what-s-new-in-python). \
+Add one using the [blurb_it]({BLURB_IT_URL}) web app or \
+the [blurb]({BLURB_PYPI_URL}) command-line tool.
 
-Please add it using the [blurb_it]({BLURB_IT_URL}) web app or the [blurb]\
-({BLURB_PYPI_URL}) command-line tool."""
+If this change has little impact on Python users, wait for a maintainer to \
+apply the `skip news` label instead.
+"""
 
 
 async def check_news(gh, pull_request, files=None):

--- a/bedevere/prtype.py
+++ b/bedevere/prtype.py
@@ -43,9 +43,9 @@ async def classify_by_filepaths(gh, pull_request, filenames):
         if util.is_news_dir(filename):
             news = True
         filepath = pathlib.PurePath(filename)
-        if filepath.suffix == '.rst':
+        if filepath.suffix == ".rst":
             docs = True
-        elif filepath.name.startswith('test_'):
+        elif filepath.name.startswith("test_"):
             tests = True
         else:
             return pr_labels

--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -9,7 +9,6 @@
 
 import enum
 import random
-import logging
 
 import gidgethub.routing
 
@@ -94,7 +93,6 @@ async def _remove_stage_labels(gh, issue):
 
 async def stage(gh, issue, blocked_on):
     """Remove any "awaiting" labels and apply the specified one."""
-    logging.info("Staging: issue %s, Issue labels: %s, blocked on: %s", issue["number"], issue["labels"], blocked_on.value)
     label_name = blocked_on.value
     if any(label_name == label["name"] for label in issue["labels"]):
         return
@@ -190,7 +188,6 @@ async def new_review(event, gh, *args, **kwargs):
     review = event.data["review"]
     reviewer = util.user_login(review)
     state = review["state"].lower()
-    logging.info("PR# %s Review submitted by %s", pull_request["number"], reviewer, )
     if state == "commented":
         # Don't care about comment reviews.
         return
@@ -202,13 +199,11 @@ async def new_review(event, gh, *args, **kwargs):
             return
         else:
             # Waiting for a core developer to leave a review.
-            logging.info("PR# %s, Review by non core developer, adding awaiting core review %s", pull_request["number"], reviewer )
             await stage(
                 gh, await util.issue_for_PR(gh, pull_request), Blocker.core_review
             )
     else:
         if state == "approved":
-            logging.info("PR# %s approved by core dev: %s", pull_request["number"], reviewer)
             if pull_request["state"] == "open":
                 await stage(
                     gh, await util.issue_for_PR(gh, pull_request), Blocker.merge

--- a/bedevere/stage.py
+++ b/bedevere/stage.py
@@ -14,7 +14,6 @@ import gidgethub.routing
 
 from . import util
 
-
 router = gidgethub.routing.Router()
 
 BORING_TRIGGER_PHRASE = "I have made the requested changes; please review again"

--- a/bedevere/util.py
+++ b/bedevere/util.py
@@ -7,8 +7,8 @@ import gidgethub
 from gidgethub.abc import GitHubAPI
 
 NEWS_NEXT_DIR = "Misc/NEWS.d/next/"
-PR = 'pr'
-ISSUE = 'issue'
+PR = "pr"
+ISSUE = "issue"
 DEFAULT_BODY = ""
 
 PR_BODY_TAG_NAME = f"gh-{{tag_type}}-number"
@@ -23,8 +23,8 @@ PR_BODY_TEMPLATE = f"""\
 """
 
 ISSUE_BODY_TAG_NAME = f"gh-linked-{PR}s"
-ISSUE_BODY_OPENING_TAG = f'<!-- {ISSUE_BODY_TAG_NAME} -->'
-ISSUE_BODY_CLOSING_TAG = f'<!-- /{ISSUE_BODY_TAG_NAME} -->'
+ISSUE_BODY_OPENING_TAG = f"<!-- {ISSUE_BODY_TAG_NAME} -->"
+ISSUE_BODY_CLOSING_TAG = f"<!-- /{ISSUE_BODY_TAG_NAME} -->"
 ISSUE_BODY_TASK_LIST_TEMPLATE = f"""\n
 {ISSUE_BODY_OPENING_TAG}
 ### Linked PRs
@@ -37,7 +37,7 @@ ISSUE_BODY_TASK_LIST_PATTERN = re.compile(
     rf"(?P<start>{ISSUE_BODY_OPENING_TAG})"
     rf"(?P<tasks>.*?)"
     rf"(?P<end>{ISSUE_BODY_CLOSING_TAG})",
-    flags=re.DOTALL
+    flags=re.DOTALL,
 )
 
 
@@ -154,7 +154,7 @@ def build_issue_body(pr_number: int, body: str) -> str:
 
     # If the body already contains a tasklist, only append the new PR to the list
     return ISSUE_BODY_TASK_LIST_PATTERN.sub(
-        fr"\g<start>\g<tasks>* gh-{pr_number}\n\g<end>",
+        rf"\g<start>\g<tasks>* gh-{pr_number}\n\g<end>",
         body,
         count=1,
     )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 asynctest==0.13.0
-pytest==7.4.2
+pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-aiohttp==1.0.5
 pytest-cov==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
 yarl==1.9.2
-sentry-sdk==1.33.1
+sentry-sdk==1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.0
+aiohttp==3.9.1
 appdirs==1.4.4
 async-timeout==4.0.3
 cachetools==5.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cachetools==5.3.2
 chardet==5.2.0
 gidgethub==5.3.0
 multidict==6.0.4
-packaging==23.1
+packaging==23.2
 pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ packaging==23.2
 pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
-yarl==1.9.2
+yarl==1.9.3
 sentry-sdk==1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.9.0b0
 appdirs==1.4.4
 async-timeout==4.0.3
-cachetools==5.3.1
+cachetools==5.3.2
 chardet==5.2.0
 gidgethub==5.3.0
 multidict==6.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyparsing==3.1.1
 six==1.16.0
 uritemplate==4.1.1
 yarl==1.9.2
-sentry-sdk==1.31.0
+sentry-sdk==1.33.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.0b0
+aiohttp==3.9.0
 appdirs==1.4.4
 async-timeout==4.0.3
 cachetools==5.3.2

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,28 +1,23 @@
-from aiohttp import web
-
 from unittest import mock
 
+from aiohttp import web
+from gidgethub import sansio
 
 from bedevere import __main__ as main
 
-from gidgethub import sansio
-
-
 app_installation_payload = {
-    "installation":
-        {
-            "id": 123,
-            "account": {"login": "mariatta"},
-        }
+    "installation": {
+        "id": 123,
+        "account": {"login": "mariatta"},
     }
+}
 
 
 async def test_ping(aiohttp_client):
     app = web.Application()
     app.router.add_post("/", main.main)
     client = await aiohttp_client(app)
-    headers = {"x-github-event": "ping",
-               "x-github-delivery": "1234"}
+    headers = {"x-github-event": "ping", "x-github-delivery": "1234"}
     data = {"zen": "testing is good"}
     response = await client.post("/", headers=headers, json=data)
     assert response.status == 200
@@ -32,8 +27,7 @@ async def test_success(aiohttp_client):
     app = web.Application()
     app.router.add_post("/", main.main)
     client = await aiohttp_client(app)
-    headers = {"x-github-event": "project",
-               "x-github-delivery": "1234"}
+    headers = {"x-github-event": "project", "x-github-delivery": "1234"}
     # Sending a payload that shouldn't trigger any networking, but no errors
     # either.
     data = {"action": "created"}
@@ -53,13 +47,14 @@ async def test_failure(aiohttp_client):
 
 @mock.patch("gidgethub.apps.get_installation_access_token")
 async def test_success_with_installation(get_access_token_mock, aiohttp_client):
-
-    get_access_token_mock.return_value = {'token': 'ghs_blablabla', 'expires_at': '2023-06-14T19:02:50Z'}
+    get_access_token_mock.return_value = {
+        "token": "ghs_blablabla",
+        "expires_at": "2023-06-14T19:02:50Z",
+    }
     app = web.Application()
     app.router.add_post("/", main.main)
     client = await aiohttp_client(app)
-    headers = {"x-github-event": "project",
-               "x-github-delivery": "1234"}
+    headers = {"x-github-event": "project", "x-github-delivery": "1234"}
     # Sending a payload that shouldn't trigger any networking, but no errors
     # either.
     data = {"action": "created"}
@@ -69,7 +64,6 @@ async def test_success_with_installation(get_access_token_mock, aiohttp_client):
 
 
 class FakeGH:
-
     def __init__(self):
         pass
 
@@ -80,9 +74,11 @@ async def test_repo_installation_added(capfd):
     }
     event_data.update(app_installation_payload)
 
-    event = sansio.Event(event_data, event='installation',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="installation", delivery_id="1")
     gh = FakeGH()
     await main.router.dispatch(event, gh)
     out, err = capfd.readouterr()
-    assert f"App installed by {event.data['installation']['account']['login']}, installation_id: {event.data['installation']['id']}" in out
+    assert (
+        f"App installed by {event.data['installation']['account']['login']}, installation_id: {event.data['installation']['id']}"
+        in out
+    )

--- a/tests/test_backport.py
+++ b/tests/test_backport.py
@@ -1,12 +1,10 @@
 import pytest
-
 from gidgethub import sansio
 
 from bedevere import backport
 
 
 class FakeGH:
-
     def __init__(self, *, getitem=None, delete=None, post=None):
         self._getitem_return = getitem
         self._delete_return = delete
@@ -27,19 +25,18 @@ class FakeGH:
         self.post_.append((post_url, data))
 
 
-@pytest.fixture(params=['gh', 'GH'])
+@pytest.fixture(params=["gh", "GH"])
 def pr_prefix(request):
     return request.param
 
 
 async def test_edit_not_title():
     data = {
-        'action': 'edited',
-        'pull_request': {'title': 'Backport this (GH-1234)', 'body': ''},
-        'changes': {},
+        "action": "edited",
+        "pull_request": {"title": "Backport this (GH-1234)", "body": ""},
+        "changes": {},
     }
-    event = sansio.Event(data, event='pull_request',
-                         delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
     assert gh.getitem_url is None
@@ -47,18 +44,17 @@ async def test_edit_not_title():
 
 async def test_missing_branch_in_title():
     data = {
-        'action': 'opened',
-        'pull_request': {
-            'title': 'Backport this (GH-1234)',
-            'body': '',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "pull_request": {
+            "title": "Backport this (GH-1234)",
+            "body": "",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
     }
-    event = sansio.Event(data, event='pull_request',
-                         delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
     assert gh.getitem_url is None
@@ -66,41 +62,39 @@ async def test_missing_branch_in_title():
 
 async def test_missing_pr_in_title():
     data = {
-        'action': 'opened',
-        'pull_request': {
-            'title': '[3.6] Backport this',
-            'body': '',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "pull_request": {
+            "title": "[3.6] Backport this",
+            "body": "",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
     }
-    event = sansio.Event(data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
     assert gh.getitem_url is None
 
 
 async def test_missing_backport_label():
-    title = '[3.6] Backport this (GH-1234)'
+    title = "[3.6] Backport this (GH-1234)"
     data = {
-        'action': 'opened',
-        'number': 2248,
-        'pull_request': {
-            'title': title,
-            'body': '',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "number": 2248,
+        "pull_request": {
+            "title": title,
+            "body": "",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {'issues_url': 'https://api.github.com/issue{/number}'}
+        "repository": {"issues_url": "https://api.github.com/issue{/number}"},
     }
-    event = sansio.Event(data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     getitem = {
         "https://api.github.com/issue/1234": {
             "labels": [{"name": "CLA signed"}],
@@ -115,43 +109,43 @@ async def test_missing_backport_label():
 
 async def test_backport_label_removal_success(pr_prefix):
     event_data = {
-        'action': 'opened',
-        'number': 2248,
-        'pull_request': {
-            'title': '[3.6] Backport this …',
-            'body': f'…({pr_prefix}-1234)',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "number": 2248,
+        "pull_request": {
+            "title": "[3.6] Backport this …",
+            "body": f"…({pr_prefix}-1234)",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {
-            'issues_url': 'https://api.github.com/issue{/number}',
+        "repository": {
+            "issues_url": "https://api.github.com/issue{/number}",
         },
     }
-    event = sansio.Event(event_data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     getitem_data = {
-        'https://api.github.com/issue/1234': {
-            'labels': [{'name': 'needs backport to 3.6'}],
-            'labels_url': 'https://api.github.com/issue/1234/labels{/name}',
-            'comments_url': 'https://api.github.com/issue/1234/comments',
+        "https://api.github.com/issue/1234": {
+            "labels": [{"name": "needs backport to 3.6"}],
+            "labels_url": "https://api.github.com/issue/1234/labels{/name}",
+            "comments_url": "https://api.github.com/issue/1234/comments",
         },
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem_data)
     await backport.router.dispatch(event, gh)
-    issue_data = getitem_data['https://api.github.com/issue/1234']
-    assert gh.delete_url == sansio.format_url(issue_data['labels_url'],
-                                              {'name': 'needs backport to 3.6'})
+    issue_data = getitem_data["https://api.github.com/issue/1234"]
+    assert gh.delete_url == sansio.format_url(
+        issue_data["labels_url"], {"name": "needs backport to 3.6"}
+    )
     assert len(gh.post_) > 0
     expected_post = None
     for post in gh.post_:
-        if post[0] == issue_data['comments_url']:
+        if post[0] == issue_data["comments_url"]:
             expected_post = post
-            message = post[1]['body']
-            assert message == backport.MESSAGE_TEMPLATE.format(branch='3.6', pr='2248')
+            message = post[1]["body"]
+            assert message == backport.MESSAGE_TEMPLATE.format(branch="3.6", pr="2248")
 
     assert expected_post is not None
 
@@ -192,106 +186,105 @@ async def test_backport_link_comment_without_label(pr_prefix):
             expected_post = post
             message = post[1]["body"]
             assert message == backport.MESSAGE_TEMPLATE.format(branch="3.6", pr="2248")
-    
+
     assert expected_post is not None
 
 
 async def test_backport_label_removal_with_leading_space_in_title(pr_prefix):
     event_data = {
-        'action': 'opened',
-        'number': 2248,
-        'pull_request': {
-            'title': f'  [3.6] Backport this ({pr_prefix}-1234)',
-            'body': '…',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "number": 2248,
+        "pull_request": {
+            "title": f"  [3.6] Backport this ({pr_prefix}-1234)",
+            "body": "…",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {
-            'issues_url': 'https://api.github.com/issue{/number}',
+        "repository": {
+            "issues_url": "https://api.github.com/issue{/number}",
         },
     }
-    event = sansio.Event(event_data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     getitem_data = {
-        'https://api.github.com/issue/1234': {
-            'labels': [{'name': 'needs backport to 3.6'}],
-            'labels_url': 'https://api.github.com/issue/1234/labels{/name}',
-            'comments_url': 'https://api.github.com/issue/1234/comments',
+        "https://api.github.com/issue/1234": {
+            "labels": [{"name": "needs backport to 3.6"}],
+            "labels_url": "https://api.github.com/issue/1234/labels{/name}",
+            "comments_url": "https://api.github.com/issue/1234/comments",
         },
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem_data)
     await backport.router.dispatch(event, gh)
-    issue_data = getitem_data['https://api.github.com/issue/1234']
-    assert gh.delete_url == sansio.format_url(issue_data['labels_url'],
-                                              {'name': 'needs backport to 3.6'})
+    issue_data = getitem_data["https://api.github.com/issue/1234"]
+    assert gh.delete_url == sansio.format_url(
+        issue_data["labels_url"], {"name": "needs backport to 3.6"}
+    )
 
 
 async def test_backport_label_removal_with_parentheses_in_title(pr_prefix):
     event_data = {
-        'action': 'opened',
-        'number': 2248,
-        'pull_request': {
-            'title': f'[3.6] Backport (0.9.6) this (more bpo-1234) ({pr_prefix}-1234)',
-            'body': '…',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "number": 2248,
+        "pull_request": {
+            "title": f"[3.6] Backport (0.9.6) this (more bpo-1234) ({pr_prefix}-1234)",
+            "body": "…",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {
-            'issues_url': 'https://api.github.com/issue{/number}',
+        "repository": {
+            "issues_url": "https://api.github.com/issue{/number}",
         },
     }
-    event = sansio.Event(event_data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     getitem_data = {
-        'https://api.github.com/issue/1234': {
-            'labels': [{'name': 'needs backport to 3.6'}],
-            'labels_url': 'https://api.github.com/issue/1234/labels{/name}',
-            'comments_url': 'https://api.github.com/issue/1234/comments',
+        "https://api.github.com/issue/1234": {
+            "labels": [{"name": "needs backport to 3.6"}],
+            "labels_url": "https://api.github.com/issue/1234/labels{/name}",
+            "comments_url": "https://api.github.com/issue/1234/comments",
         },
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem_data)
     await backport.router.dispatch(event, gh)
-    issue_data = getitem_data['https://api.github.com/issue/1234']
-    assert gh.delete_url == sansio.format_url(issue_data['labels_url'],
-                                              {'name': 'needs backport to 3.6'})
+    issue_data = getitem_data["https://api.github.com/issue/1234"]
+    assert gh.delete_url == sansio.format_url(
+        issue_data["labels_url"], {"name": "needs backport to 3.6"}
+    )
 
 
 async def test_label_copying(pr_prefix):
     event_data = {
-        'action': 'opened',
-        'number': 2248,
-        'pull_request': {
-            'title': f'[3.6] Backport this ({pr_prefix}-1234)',
-            'body': 'N/A',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": "opened",
+        "number": 2248,
+        "pull_request": {
+            "title": f"[3.6] Backport this ({pr_prefix}-1234)",
+            "body": "N/A",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {
-            'issues_url': 'https://api.github.com/issue{/number}',
+        "repository": {
+            "issues_url": "https://api.github.com/issue{/number}",
         },
     }
-    event = sansio.Event(event_data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     labels_to_test = "CLA signed", "skip news", "type-enhancement", "sprint"
     getitem_data = {
-        'https://api.github.com/issue/1234': {
-            'labels': [{'name': label} for label in labels_to_test],
-            'labels_url': 'https://api.github.com/issue/1234/labels{/name}',
-            'comments_url': 'https://api.github.com/issue/1234/comments',
+        "https://api.github.com/issue/1234": {
+            "labels": [{"name": label} for label in labels_to_test],
+            "labels_url": "https://api.github.com/issue/1234/labels{/name}",
+            "comments_url": "https://api.github.com/issue/1234/comments",
         },
-        'https://api.github.com/issue/2248': {
-            'labels_url': 'https://api.github.com/issue/1234/labels{/name}',
+        "https://api.github.com/issue/2248": {
+            "labels_url": "https://api.github.com/issue/1234/labels{/name}",
         },
     }
     gh = FakeGH(getitem=getitem_data)
@@ -299,171 +292,169 @@ async def test_label_copying(pr_prefix):
     assert len(gh.post_) > 0
     expected_post = None
     for post in gh.post_:
-        if post[0] == 'https://api.github.com/issue/1234/labels':
-            assert {'skip news', 'type-enhancement', 'sprint'} == frozenset(post[1])
+        if post[0] == "https://api.github.com/issue/1234/labels":
+            assert {"skip news", "type-enhancement", "sprint"} == frozenset(post[1])
             expected_post = post
 
     assert expected_post is not None
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'edited', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "edited", "synchronize"])
 async def test_valid_maintenance_branch_pr_title(action):
-    title = '[3.6] Fix to a maintenance branch'
+    title = "[3.6] Fix to a maintenance branch"
     data = {
-        'action': action,
-        'number': 2248,
-        'pull_request': {
-            'title': title,
-            'body': '',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": action,
+        "number": 2248,
+        "pull_request": {
+            "title": title,
+            "body": "",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {'issues_url': 'https://api.github.com/issue{/number}'},
-        'changes': {'title': title},
+        "repository": {"issues_url": "https://api.github.com/issue{/number}"},
+        "changes": {"title": title},
     }
-    event = sansio.Event(data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     getitem = {
-        'https://api.github.com/issue/1234':
-            {'labels': [{'name': 'CLA signed'}]},
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/1234": {"labels": [{"name": "CLA signed"}]},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem)
     await backport.router.dispatch(event, gh)
     post = gh.post_[0]
-    assert post[0] == 'https://api.github.com/repos/python/cpython/statuses/somehash'
-    assert post[1]['context'] == 'bedevere/maintenance-branch-pr'
-    assert post[1]['description'] == 'Valid maintenance branch PR title.'
-    assert post[1]['state'] == 'success'
+    assert post[0] == "https://api.github.com/repos/python/cpython/statuses/somehash"
+    assert post[1]["context"] == "bedevere/maintenance-branch-pr"
+    assert post[1]["description"] == "Valid maintenance branch PR title."
+    assert post[1]["state"] == "success"
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'edited', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "edited", "synchronize"])
 async def test_not_valid_maintenance_branch_pr_title(action):
-    title = 'Fix some typo'
+    title = "Fix some typo"
     data = {
-        'action': action,
-        'number': 2248,
-        'pull_request': {
-            'title': title,
-            'body': '',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': '3.6',
+        "action": action,
+        "number": 2248,
+        "pull_request": {
+            "title": title,
+            "body": "",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "3.6",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {'issues_url': 'https://api.github.com/issue{/number}'},
-        'changes': {'title': title},
+        "repository": {"issues_url": "https://api.github.com/issue{/number}"},
+        "changes": {"title": title},
     }
-    event = sansio.Event(data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     getitem = {
-        'https://api.github.com/issue/1234':
-            {'labels': [{'name': 'CLA signed'}]},
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/1234": {"labels": [{"name": "CLA signed"}]},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem)
     await backport.router.dispatch(event, gh)
     post = gh.post_[0]
-    assert post[0] == 'https://api.github.com/repos/python/cpython/statuses/somehash'
-    assert post[1]['context'] == 'bedevere/maintenance-branch-pr'
-    assert post[1]['description'] == 'Not a valid maintenance branch PR title.'
-    assert post[1]['state'] == 'failure'
-    assert post[1]['target_url'] == 'https://devguide.python.org/committing/#backport-pr-title'
+    assert post[0] == "https://api.github.com/repos/python/cpython/statuses/somehash"
+    assert post[1]["context"] == "bedevere/maintenance-branch-pr"
+    assert post[1]["description"] == "Not a valid maintenance branch PR title."
+    assert post[1]["state"] == "failure"
+    assert (
+        post[1]["target_url"]
+        == "https://devguide.python.org/committing/#backport-pr-title"
+    )
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'edited', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "edited", "synchronize"])
 async def test_maintenance_branch_pr_status_not_posted_on_main(action):
-    title = 'Fix some typo'
+    title = "Fix some typo"
     data = {
-        'action': action,
-        'number': 2248,
-        'pull_request': {
-            'title': title,
-            'body': '',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': 'main',
+        "action": action,
+        "number": 2248,
+        "pull_request": {
+            "title": title,
+            "body": "",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "main",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {'issues_url': 'https://api.github.com/issue{/number}'},
-        'changes': {'title': title},
+        "repository": {"issues_url": "https://api.github.com/issue{/number}"},
+        "changes": {"title": title},
     }
-    event = sansio.Event(data, event='pull_request',
-                        delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     getitem = {
-        'https://api.github.com/issue/1234':
-            {'labels': [{'name': 'CLA signed'}]},
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/1234": {"labels": [{"name": "CLA signed"}]},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem)
     await backport.router.dispatch(event, gh)
     assert len(gh.post_) == 0
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'edited', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "edited", "synchronize"])
 async def test_not_maintenance_branch_pr_status_not_posted_alt_base(action):
     """
     When a PR is proposed against a non-maintenance branch, such
     as another PR, it pass without status (same as with main). See
     #381 for a detailed justification.
     """
-    title = 'Fix some typo'
+    title = "Fix some typo"
     data = {
-        'action': action,
-        'number': 2248,
-        'pull_request': {
-            'title': title,
-            'body': '',
-            'issue_url': 'https://api.github.com/issue/2248',
-            'base': {
-                'ref': 'gh-1234/dependent-change',
+        "action": action,
+        "number": 2248,
+        "pull_request": {
+            "title": title,
+            "body": "",
+            "issue_url": "https://api.github.com/issue/2248",
+            "base": {
+                "ref": "gh-1234/dependent-change",
             },
-            'statuses_url': 'https://api.github.com/repos/python/cpython/statuses/somehash',
+            "statuses_url": "https://api.github.com/repos/python/cpython/statuses/somehash",
         },
-        'repository': {'issues_url': 'https://api.github.com/issue{/number}'},
-        'changes': {'title': title},
+        "repository": {"issues_url": "https://api.github.com/issue{/number}"},
+        "changes": {"title": title},
     }
-    event = sansio.Event(data, event='pull_request', delivery_id='1')
+    event = sansio.Event(data, event="pull_request", delivery_id="1")
     getitem = {
-        'https://api.github.com/issue/1234':
-            {'labels': [{'name': 'CLA signed'}]},
-        'https://api.github.com/issue/2248': {},
+        "https://api.github.com/issue/1234": {"labels": [{"name": "CLA signed"}]},
+        "https://api.github.com/issue/2248": {},
     }
     gh = FakeGH(getitem=getitem)
     await backport.router.dispatch(event, gh)
     assert not gh.post_
 
 
-@pytest.mark.parametrize('ref', ['3.9', '4.0', '3.10'])
+@pytest.mark.parametrize("ref", ["3.9", "4.0", "3.10"])
 async def test_maintenance_branch_created(ref):
     event_data = {
-        'ref': ref,
-        'ref_type': "branch",
-
+        "ref": ref,
+        "ref_type": "branch",
     }
-    event = sansio.Event(event_data, event='create',
-                        delivery_id='1')
+    event = sansio.Event(event_data, event="create", delivery_id="1")
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
     label_creation_post = gh.post_[0]
-    assert label_creation_post[0] == "https://api.github.com/repos/python/cpython/labels"
-    assert label_creation_post[1] == {'name': f"needs backport to {ref}", 'color': 'c2e0c6',
-                                      'description': 'bug and security fixes'}
+    assert (
+        label_creation_post[0] == "https://api.github.com/repos/python/cpython/labels"
+    )
+    assert label_creation_post[1] == {
+        "name": f"needs backport to {ref}",
+        "color": "c2e0c6",
+        "description": "bug and security fixes",
+    }
 
 
-@pytest.mark.parametrize('ref', ['backport-3.9', 'test', 'Mariatta-patch-1'])
+@pytest.mark.parametrize("ref", ["backport-3.9", "test", "Mariatta-patch-1"])
 async def test_other_branch_created(ref):
     event_data = {
-        'ref': ref,
-        'ref_type': "branch",
-
+        "ref": ref,
+        "ref_type": "branch",
     }
-    event = sansio.Event(event_data, event='create', delivery_id='1')
+    event = sansio.Event(event_data, event="create", delivery_id="1")
     gh = FakeGH()
     await backport.router.dispatch(event, gh)
     assert gh.post_ == []

--- a/tests/test_close_pr.py
+++ b/tests/test_close_pr.py
@@ -1,12 +1,10 @@
 import pytest
-
 from gidgethub import sansio
 
 from bedevere import close_pr
 
 
 class FakeGH:
-
     def __init__(self, *, getitem=None, post=None):
         self._getitem_return = getitem
         self.patch_url = None
@@ -41,12 +39,8 @@ async def test_close_invalid_pr_on_open():
             "title": "No issue in title",
             "issue_url": "https://api.github.com/org/repo/issues/123",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "python:3.6"
-            },
-            "base": {
-                "label": "python:main"
-            }
+            "head": {"label": "python:3.6"},
+            "base": {"label": "python:main"},
         },
     }
     pr_data = {
@@ -61,10 +55,10 @@ async def test_close_invalid_pr_on_open():
     assert patch_data["state"] == "closed"
 
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/org/repo/issues/123/labels'
-    assert gh.post_data[0] == ['invalid']
-    assert gh.post_url[1] == 'https://api.github.com/org/repo/issues/123/comments'
-    assert gh.post_data[1] == {'body': close_pr.INVALID_PR_COMMENT}
+    assert gh.post_url[0] == "https://api.github.com/org/repo/issues/123/labels"
+    assert gh.post_data[0] == ["invalid"]
+    assert gh.post_url[1] == "https://api.github.com/org/repo/issues/123/comments"
+    assert gh.post_data[1] == {"body": close_pr.INVALID_PR_COMMENT}
 
 
 @pytest.mark.asyncio
@@ -76,12 +70,8 @@ async def test_close_invalid_pr_on_synchronize():
             "title": "No issue in title",
             "issue_url": "https://api.github.com/org/repo/issues/123",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "python:3.6"
-            },
-            "base": {
-                "label": "python:main"
-            }
+            "head": {"label": "python:3.6"},
+            "base": {"label": "python:main"},
         },
     }
     pr_data = {
@@ -96,10 +86,10 @@ async def test_close_invalid_pr_on_synchronize():
     assert patch_data["state"] == "closed"
 
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/org/repo/issues/123/labels'
-    assert gh.post_data[0] == ['invalid']
-    assert gh.post_url[1] == 'https://api.github.com/org/repo/issues/123/comments'
-    assert gh.post_data[1] == {'body': close_pr.INVALID_PR_COMMENT}
+    assert gh.post_url[0] == "https://api.github.com/org/repo/issues/123/labels"
+    assert gh.post_data[0] == ["invalid"]
+    assert gh.post_url[1] == "https://api.github.com/org/repo/issues/123/comments"
+    assert gh.post_data[1] == {"body": close_pr.INVALID_PR_COMMENT}
 
 
 @pytest.mark.asyncio
@@ -111,12 +101,8 @@ async def test_valid_pr_not_closed():
             "title": "No issue in title",
             "issue_url": "issue URL",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "someuser:bpo-3.6"
-            },
-            "base": {
-                "label": "python:main"
-            }
+            "head": {"label": "someuser:bpo-3.6"},
+            "base": {"label": "python:main"},
         },
     }
     pr_data = {
@@ -140,12 +126,8 @@ async def test_close_invalid_pr_on_open_not_python_as_head():
             "title": "No issue in title",
             "issue_url": "issue URL",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "username123:3.6"
-            },
-            "base": {
-                "label": "python:main"
-            }
+            "head": {"label": "username123:3.6"},
+            "base": {"label": "python:main"},
         },
     }
     pr_data = {
@@ -169,12 +151,8 @@ async def test_pr_with_head_branch_containing_all_digits_not_closed():
             "title": "No issue in title",
             "issue_url": "issue URL",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "someuser:12345"
-            },
-            "base": {
-                "label": "python:main"
-            }
+            "head": {"label": "someuser:12345"},
+            "base": {"label": "python:main"},
         },
     }
     pr_data = {
@@ -199,12 +177,8 @@ async def test_dismiss_review_request_for_invalid_pr():
             "title": "No issue in title",
             "issue_url": "issue URL",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "python:3.6"
-            },
-            "base": {
-                "label": "python:main"
-            },
+            "head": {"label": "python:3.6"},
+            "base": {"label": "python:main"},
             "requested_reviewers": [
                 {
                     "login": "gpshead",
@@ -220,17 +194,21 @@ async def test_dismiss_review_request_for_invalid_pr():
                 {
                     "name": "windows-team",
                 },
-            ]
+            ],
         },
     }
 
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH()
     await close_pr.router.dispatch(event, gh)
-    assert gh.delete_data == {'reviewers': ['gpshead', 'gvanrossum'],
-                              'team_reviewers': ['import-team', 'windows-team']
-                              }
-    assert gh.delete_url == f"https://api.github.com/org/repo/pulls/123/requested_reviewers"
+    assert gh.delete_data == {
+        "reviewers": ["gpshead", "gvanrossum"],
+        "team_reviewers": ["import-team", "windows-team"],
+    }
+    assert (
+        gh.delete_url
+        == f"https://api.github.com/org/repo/pulls/123/requested_reviewers"
+    )
 
 
 @pytest.mark.asyncio
@@ -242,12 +220,8 @@ async def test_valid_pr_review_request_not_dismissed():
             "title": "No issue in title",
             "issue_url": "issue URL",
             "url": "https://api.github.com/org/repo/pulls/123",
-            "head": {
-                "label": "someuser:bpo-3.6"
-            },
-            "base": {
-                "label": "python:main"
-            },
+            "head": {"label": "someuser:bpo-3.6"},
+            "base": {"label": "python:main"},
             "requested_reviewers": [
                 {
                     "login": "gpshead",
@@ -263,7 +237,7 @@ async def test_valid_pr_review_request_not_dismissed():
                 {
                     "name": "windows-team",
                 },
-            ]
+            ],
         },
     }
 

--- a/tests/test_filepaths.py
+++ b/tests/test_filepaths.py
@@ -1,16 +1,13 @@
 import pytest
-
 from gidgethub import sansio
 
 from bedevere import filepaths
-
 from bedevere.prtype import Labels
 
 from .test_news import check_n_pop_nonews_events
 
 
 class FakeGH:
-
     def __init__(self, *, getiter=None, getitem=None, post=None):
         self._getitem_return = getitem
         self._getiter_return = getiter
@@ -35,168 +32,232 @@ class FakeGH:
         return self._post_return
 
 
-GOOD_BASENAME = '2017-06-16-20-32-50.bpo-1234.nonce.rst'
+GOOD_BASENAME = "2017-06-16-20-32-50.bpo-1234.nonce.rst"
 
 
 async def test_news_only():
-    filenames = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 ]
-    issue = {'labels': []}
+    filenames = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+    ]
+    issue = {"labels": []}
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
+    assert gh.post_url[0] == "https://api.github.com/some/status"
+    assert gh.post_data[0]["state"] == "success"
 
 
-@pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
+@pytest.mark.parametrize(
+    "author_association", ["OWNER", "MEMBER", "CONTRIBUTOR", "NONE"]
+)
 async def test_docs_only(author_association):
-    filenames = [{'filename': '/path/to/docs1.rst', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': 'docs2.rst', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 ]
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = [
+        {
+            "filename": "/path/to/docs1.rst",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": "docs2.rst",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+    ]
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
-            'issue_comment_url': 'https://api.github.com/repos/cpython/python/issue/1234/comments',
-            'author_association': author_association,
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+            "issue_comment_url": "https://api.github.com/repos/cpython/python/issue/1234/comments",
+            "author_association": author_association,
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.docs.value, Labels.skip_news.value]
 
 
-@pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
+@pytest.mark.parametrize(
+    "author_association", ["OWNER", "MEMBER", "CONTRIBUTOR", "NONE"]
+)
 async def test_tests_only(author_association):
-    filenames = [{'filename': '/path/to/test_docs1.py', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': 'test_docs2.py', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 ]
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = [
+        {
+            "filename": "/path/to/test_docs1.py",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": "test_docs2.py",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+    ]
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
-            'issue_comment_url': 'https://api.github.com/repos/cpython/python/issue/1234/comments',
-            'author_association': author_association,
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+            "issue_comment_url": "https://api.github.com/repos/cpython/python/issue/1234/comments",
+            "author_association": author_association,
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    assert len(gh.post_url) == 3 if author_association == 'NONE' else 2
-    assert gh.post_url.pop(0) == 'https://api.github.com/some/label'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
+    assert len(gh.post_url) == 3 if author_association == "NONE" else 2
+    assert gh.post_url.pop(0) == "https://api.github.com/some/label"
     assert gh.post_data.pop(0) == [Labels.tests.value]
-    check_n_pop_nonews_events(gh, author_association == 'NONE')
+    check_n_pop_nonews_events(gh, author_association == "NONE")
 
 
 async def test_docs_and_tests():
-    filenames = [{'filename': '/path/to/docs.rst', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': 'test_docs2.py', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 ]
-    issue = {'labels': [{'name': 'skip news'}],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = [
+        {
+            "filename": "/path/to/docs.rst",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": "test_docs2.py",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+    ]
+    issue = {
+        "labels": [{"name": "skip news"}],
+        "labels_url": "https://api.github.com/some/label",
+    }
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # Only creates type-tests label.
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.tests.value]
-    assert gh.post_url[1] == 'https://api.github.com/some/status'
-    assert gh.post_data[1]['state'] == 'success'
+    assert gh.post_url[1] == "https://api.github.com/some/status"
+    assert gh.post_data[1]["state"] == "success"
 
 
 async def test_news_and_tests():
-    filenames = [{'filename': '/path/to/docs.rst', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': 'test_docs2.py', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'}]
+    filenames = [
+        {
+            "filename": "/path/to/docs.rst",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": "test_docs2.py",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
 
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # Only creates type-tests label.
     assert len(gh.post_url) == 2
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.tests.value]
-    assert gh.post_url[1] == 'https://api.github.com/some/status'
-    assert gh.post_data[1]['state'] == 'success'
+    assert gh.post_url[1] == "https://api.github.com/some/status"
+    assert gh.post_data[1]["state"] == "success"
 
 
 async def test_synchronize():
-    filenames = [{'filename': '/path/to/docs.rst', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': 'test_docs2.py', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-                 {'filename': f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'}]
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = [
+        {
+            "filename": "/path/to/docs.rst",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": "test_docs2.py",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'synchronize',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "synchronize",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await filepaths.router.dispatch(event, gh)
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
     assert gh.getitem_url is None
     # Only creates type-tests label.
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
+    assert gh.post_url[0] == "https://api.github.com/some/status"
+    assert gh.post_data[0]["state"] == "success"

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -1,17 +1,15 @@
+import http
 from unittest import mock
 
-import http
 import aiohttp
-import pytest
 import gidgethub
-
+import pytest
 from gidgethub import sansio
 
 from bedevere import gh_issue
 
 
 class FakeGH:
-
     def __init__(self, *, getitem=None, post=None, patch=None):
         self._getitem_return = getitem
         self._post_return = post
@@ -45,8 +43,9 @@ async def issue_number():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_failure(action, monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -61,7 +60,7 @@ async def test_set_status_failure(action, monkeypatch):
         "url": "url",
         "labels": [
             {"name": "non-trivial"},
-        ]
+        ],
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=issue_data)
@@ -76,8 +75,9 @@ async def test_set_status_failure(action, monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_failure_via_issue_not_found_on_github(action, monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=False)
+    )
 
     data = {
         "action": action,
@@ -133,8 +133,9 @@ async def test_set_status_success_issue_found_on_bpo(action):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_success(action, monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -155,14 +156,17 @@ async def test_set_status_success(action, monkeypatch):
     assert "1234" in status["description"]
     assert status["context"] == "bedevere/issue-number"
     assert "git-sha" in gh.post_url[0]
-    gh_issue._validate_issue_number.assert_awaited_with(gh, 1234, session=None, kind="gh")
+    gh_issue._validate_issue_number.assert_awaited_with(
+        gh, 1234, session=None, kind="gh"
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_success_issue_found_on_gh(action, monkeypatch, issue_number):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -180,7 +184,10 @@ async def test_set_status_success_issue_found_on_gh(action, monkeypatch, issue_n
         await gh_issue.router.dispatch(event, gh, session=session)
     status = gh.post_data[0]
     assert status["state"] == "success"
-    assert status["target_url"] == f"https://github.com/python/cpython/issues/{issue_number}"
+    assert (
+        status["target_url"]
+        == f"https://github.com/python/cpython/issues/{issue_number}"
+    )
     assert str(issue_number) in status["description"]
     assert status["context"] == "bedevere/issue-number"
     assert "git-sha" in gh.post_url[0]
@@ -199,9 +206,12 @@ async def test_set_status_success_issue_found_on_gh(action, monkeypatch, issue_n
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
-async def test_set_status_success_issue_found_on_gh_ignore_case(action, monkeypatch, issue_number):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+async def test_set_status_success_issue_found_on_gh_ignore_case(
+    action, monkeypatch, issue_number
+):
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -219,7 +229,10 @@ async def test_set_status_success_issue_found_on_gh_ignore_case(action, monkeypa
         await gh_issue.router.dispatch(event, gh, session=session)
     status = gh.post_data[0]
     assert status["state"] == "success"
-    assert status["target_url"] == f"https://github.com/python/cpython/issues/{issue_number}"
+    assert (
+        status["target_url"]
+        == f"https://github.com/python/cpython/issues/{issue_number}"
+    )
     assert str(issue_number) in status["description"]
     assert status["context"] == "bedevere/issue-number"
     assert "git-sha" in gh.post_url[0]
@@ -239,8 +252,9 @@ async def test_set_status_success_issue_found_on_gh_ignore_case(action, monkeypa
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_success_via_skip_issue_label(action, monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -255,7 +269,7 @@ async def test_set_status_success_via_skip_issue_label(action, monkeypatch):
         "url": "url",
         "labels": [
             {"name": "skip issue"},
-        ]
+        ],
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=issue_data)
@@ -269,11 +283,13 @@ async def test_set_status_success_via_skip_issue_label(action, monkeypatch):
     assert len(gh.patch_data) == 0
     assert len(gh.patch_url) == 0
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action", ["opened", "synchronize", "reopened"])
 async def test_set_status_success_via_skip_issue_label_pr_in_title(action, monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=False)
+    )
     data = {
         "action": action,
         "pull_request": {
@@ -288,7 +304,7 @@ async def test_set_status_success_via_skip_issue_label_pr_in_title(action, monke
         "url": "url",
         "labels": [
             {"name": "skip issue"},
-        ]
+        ],
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=issue_data)
@@ -305,8 +321,9 @@ async def test_set_status_success_via_skip_issue_label_pr_in_title(action, monke
 
 @pytest.mark.asyncio
 async def test_edit_title(monkeypatch, issue_number):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "pull_request": {
             "statuses_url": "https://api.github.com/blah/blah/git-sha",
@@ -323,12 +340,16 @@ async def test_edit_title(monkeypatch, issue_number):
     gh = FakeGH(getitem=issue_data)
     await gh_issue.router.dispatch(event, gh, session=None)
     assert len(gh.post_data) == 1
-    gh_issue._validate_issue_number.assert_awaited_with(gh, issue_number, session=None, kind="gh")
+    gh_issue._validate_issue_number.assert_awaited_with(
+        gh, issue_number, session=None, kind="gh"
+    )
+
 
 @pytest.mark.asyncio
 async def test_no_body_when_edit_title(monkeypatch, issue_number):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": "edited",
         "pull_request": {
@@ -347,7 +368,9 @@ async def test_no_body_when_edit_title(monkeypatch, issue_number):
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     gh = FakeGH(getitem=issue_data)
     await gh_issue.router.dispatch(event, gh, session=None)
-    gh_issue._validate_issue_number.assert_awaited_with(gh, issue_number, session=None, kind="gh")
+    gh_issue._validate_issue_number.assert_awaited_with(
+        gh, issue_number, session=None, kind="gh"
+    )
 
     assert len(gh.patch_data) > 0
     assert f"<!-- gh-issue-number: gh-{issue_number} -->" in gh.patch_data[0]["body"]
@@ -363,8 +386,9 @@ async def test_no_body_when_edit_title(monkeypatch, issue_number):
 
 @pytest.mark.asyncio
 async def test_edit_other_than_title(monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "pull_request": {
             "statuses_url": "https://api.github.com/blah/blah/git-sha",
@@ -457,6 +481,7 @@ async def test_new_label_skip_issue_with_issue_number_ignore_case():
     assert status["context"] == "bedevere/issue-number"
     assert "git-sha" in gh.post_url[0]
 
+
 @pytest.mark.asyncio
 async def test_new_label_not_skip_issue():
     data = {
@@ -480,8 +505,9 @@ async def test_new_label_not_skip_issue():
 async def test_removed_label_from_label_deletion(monkeypatch):
     """When a label is completely deleted from a repo, it triggers an 'unlabeled'
     event, but the payload has no details about the removed label."""
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": "unlabeled",
         # No "label" key.
@@ -503,8 +529,9 @@ async def test_removed_label_from_label_deletion(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_removed_label_skip_issue(monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": "unlabeled",
         "label": {"name": "skip issue"},
@@ -526,13 +553,16 @@ async def test_removed_label_skip_issue(monkeypatch):
     assert "1234" in status["description"]
     assert status["context"] == "bedevere/issue-number"
     assert "git-sha" in gh.post_url[0]
-    gh_issue._validate_issue_number.assert_awaited_with(gh, 1234, session=None, kind="gh")
+    gh_issue._validate_issue_number.assert_awaited_with(
+        gh, 1234, session=None, kind="gh"
+    )
 
 
 @pytest.mark.asyncio
 async def test_removed_label_non_skip_issue(monkeypatch):
-    monkeypatch.setattr(gh_issue, '_validate_issue_number',
-                        mock.AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        gh_issue, "_validate_issue_number", mock.AsyncMock(return_value=True)
+    )
     data = {
         "action": "unlabeled",
         "label": {"name": "non-trivial"},
@@ -553,7 +583,6 @@ async def test_removed_label_non_skip_issue(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_validate_issue_number_valid_on_github():
-
     gh = FakeGH(getitem={"number": 123})
     async with aiohttp.ClientSession() as session:
         response = await gh_issue._validate_issue_number(gh, 123, session=session)
@@ -572,15 +601,16 @@ async def test_validate_issue_number_valid_on_bpo():
 
 @pytest.mark.asyncio
 async def test_validate_issue_number_is_pr_on_github():
-
-    gh = FakeGH(getitem={
-        "number": 123,
-        "pull_request": {
-            "html_url": "https://github.com/python/cpython/pull/123",
-            "url": "url",
-            "number": 1234,
+    gh = FakeGH(
+        getitem={
+            "number": 123,
+            "pull_request": {
+                "html_url": "https://github.com/python/cpython/pull/123",
+                "url": "url",
+                "number": 1234,
+            },
         }
-    })
+    )
     async with aiohttp.ClientSession() as session:
         response = await gh_issue._validate_issue_number(gh, 123, session=session)
     assert response is False
@@ -588,11 +618,7 @@ async def test_validate_issue_number_is_pr_on_github():
 
 @pytest.mark.asyncio
 async def test_validate_issue_number_is_not_valid():
-    gh = FakeGH(
-        getitem=gidgethub.BadRequest(
-            status_code=http.HTTPStatus(404)
-        )
-    )
+    gh = FakeGH(getitem=gidgethub.BadRequest(status_code=http.HTTPStatus(404)))
     async with aiohttp.ClientSession() as session:
         response = await gh_issue._validate_issue_number(gh, 123, session=session)
     assert response is False

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,5 +1,4 @@
 import pytest
-
 from gidgethub import sansio
 
 from bedevere import news
@@ -7,16 +6,18 @@ from bedevere import news
 
 def check_n_pop_nonews_events(gh, expect_help):
     if expect_help:
-        assert gh.post_url.pop(0) == 'https://api.github.com/repos/cpython/python/issue/1234/comments'
-        assert gh.post_data.pop(0)['body'] == news.HELP
-    assert gh.post_url.pop(0) == 'https://api.github.com/some/status'
+        assert (
+            gh.post_url.pop(0)
+            == "https://api.github.com/repos/cpython/python/issue/1234/comments"
+        )
+        assert gh.post_data.pop(0)["body"] == news.HELP
+    assert gh.post_url.pop(0) == "https://api.github.com/some/status"
     post_data = gh.post_data.pop(0)
-    assert post_data['state'] == 'failure'
-    assert post_data['target_url'] == news.BLURB_IT_URL
+    assert post_data["state"] == "failure"
+    assert post_data["target_url"] == news.BLURB_IT_URL
 
 
 class FakeGH:
-
     def __init__(self, *, getiter=None, getitem=None, post=None):
         self._getitem_return = getitem
         self._getiter_return = getiter
@@ -41,175 +42,225 @@ class FakeGH:
         return self._post_return
 
 
-GOOD_BASENAME = '2017-06-16-20-32-50.gh-issue-1234.nonce.rst'
-BPO_BASENAME = '2017-06-16-20-32-50.bpo-1234.nonce.rst'
+GOOD_BASENAME = "2017-06-16-20-32-50.gh-issue-1234.nonce.rst"
+BPO_BASENAME = "2017-06-16-20-32-50.bpo-1234.nonce.rst"
 
 
 class TestFilenameRE:
-
     def test_malformed_basename(self):
-        assert news.FILENAME_RE.match('2017-06-16.gh-issue-1234.rst') is None
-        assert news.FILENAME_RE.match('2017-06-16.gh-1234.rst') is None
+        assert news.FILENAME_RE.match("2017-06-16.gh-issue-1234.rst") is None
+        assert news.FILENAME_RE.match("2017-06-16.gh-1234.rst") is None
 
     def test_success(self):
         assert news.FILENAME_RE.match(GOOD_BASENAME)
-        live_result = '2017-08-14-15-13-50.gh-issue-1612262.-x_Oyq.rst'
+        live_result = "2017-08-14-15-13-50.gh-issue-1612262.-x_Oyq.rst"
         assert news.FILENAME_RE.match(live_result)
 
     def test_multiple_issue_numbers(self):
-        basename = '2018-01-01.gh-issue-1234,5678,9012.nonce.rst'
+        basename = "2018-01-01.gh-issue-1234,5678,9012.nonce.rst"
         assert news.FILENAME_RE.match(basename)
 
     def test_date_only(self):
-        basename = '2017-08-14.gh-issue-1234.nonce.rst'
+        basename = "2017-08-14.gh-issue-1234.nonce.rst"
         assert news.FILENAME_RE.match(basename)
 
     def test_malformed_basename_bpo(self):
-        assert news.FILENAME_RE.match('2017-06-16.bpo-1234.rst') is None
+        assert news.FILENAME_RE.match("2017-06-16.bpo-1234.rst") is None
 
     def test_success_bpo(self):
         assert news.FILENAME_RE.match(BPO_BASENAME)
-        live_result = '2017-08-14-15-13-50.bpo-1612262.-x_Oyq.rst'
+        live_result = "2017-08-14-15-13-50.bpo-1612262.-x_Oyq.rst"
         assert news.FILENAME_RE.match(live_result)
 
     def test_multiple_issue_numbers_bpo(self):
-        basename = '2018-01-01.bpo-1234,5678,9012.nonce.rst'
+        basename = "2018-01-01.bpo-1234,5678,9012.nonce.rst"
         assert news.FILENAME_RE.match(basename)
 
     def test_date_only_bpo(self):
-        basename = '2017-08-14.bpo-1234.nonce.rst'
+        basename = "2017-08-14.bpo-1234.nonce.rst"
         assert news.FILENAME_RE.match(basename)
 
 
 async def failure_testing(path, action, author_association):
-    files = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-             {'filename': path, 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'},
-             ]
-    issue = {'labels': []}
+    files = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": path,
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
+    issue = {"labels": []}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
-        'action': action,
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
-            'issue_comment_url': 'https://api.github.com/repos/cpython/python/issue/1234/comments',
-            'author_association': author_association,
+        "action": action,
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+            "issue_comment_url": "https://api.github.com/repos/cpython/python/issue/1234/comments",
+            "author_association": author_association,
         },
     }
-    await news.check_news(gh, event_data['pull_request'])
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    check_n_pop_nonews_events(gh, author_association == 'NONE')
+    await news.check_news(gh, event_data["pull_request"])
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
+    check_n_pop_nonews_events(gh, author_association == "NONE")
     assert not gh.post_url
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
-@pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "synchronize"])
+@pytest.mark.parametrize(
+    "author_association", ["OWNER", "MEMBER", "CONTRIBUTOR", "NONE"]
+)
 async def test_bad_news_entry(action, author_association):
     # Not in Misc/NEWS.d.
-    await failure_testing(f'some/other/dir/{GOOD_BASENAME}', action, author_association)
+    await failure_testing(f"some/other/dir/{GOOD_BASENAME}", action, author_association)
     # Not in next/.
-    await failure_testing(f'Misc/NEWS.d/{GOOD_BASENAME}', action, author_association)
+    await failure_testing(f"Misc/NEWS.d/{GOOD_BASENAME}", action, author_association)
     # Not in a classifying subdirectory.
-    await failure_testing(f'Misc/NEWS.d/next/{GOOD_BASENAME}', action, author_association)
+    await failure_testing(
+        f"Misc/NEWS.d/next/{GOOD_BASENAME}", action, author_association
+    )
     # Missing the nonce.
-    await failure_testing(f'Misc/NEWS.d/next/Library/2017-06-16.bpo-1234.rst', action, author_association)
+    await failure_testing(
+        f"Misc/NEWS.d/next/Library/2017-06-16.bpo-1234.rst", action, author_association
+    )
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "synchronize"])
 async def test_skip_news(action):
-    files = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-             {'filename': f'Misc/NEWS.d/next/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'},
-             ]
-    issue = {'labels': [{'name': 'skip news'}]}
+    files = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
+    issue = {"labels": [{"name": "skip news"}]}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
-        'action': action,
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": action,
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await news.check_news(gh, event_data['pull_request'])
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
-    assert gh.post_data[0].get('target_url') is None
+    await news.check_news(gh, event_data["pull_request"])
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
+    assert gh.post_url[0] == "https://api.github.com/some/status"
+    assert gh.post_data[0]["state"] == "success"
+    assert gh.post_data[0].get("target_url") is None
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "synchronize"])
 async def test_news_file(action):
-    files = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-             {'filename': f'Misc/NEWS.d/next/Library/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'},
-             ]
-    issue = {'labels': [{'name': 'CLA signed'}]}
+    files = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/Library/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
+    issue = {"labels": [{"name": "CLA signed"}]}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
-        'action': action,
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": action,
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await news.check_news(gh, event_data['pull_request'])
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
-    assert gh.post_data[0].get('target_url') is None
+    await news.check_news(gh, event_data["pull_request"])
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.post_url[0] == "https://api.github.com/some/status"
+    assert gh.post_data[0]["state"] == "success"
+    assert gh.post_data[0].get("target_url") is None
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
-@pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "synchronize"])
+@pytest.mark.parametrize(
+    "author_association", ["OWNER", "MEMBER", "CONTRIBUTOR", "NONE"]
+)
 async def test_empty_news_file(action, author_association):
-    files = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-             {'filename': f'Misc/NEWS.d/next/Library/{GOOD_BASENAME}'},
-             ]
-    issue = {'labels': [{'name': 'CLA signed'}]}
+    files = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {"filename": f"Misc/NEWS.d/next/Library/{GOOD_BASENAME}"},
+    ]
+    issue = {"labels": [{"name": "CLA signed"}]}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
-        'action': action,
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
-            'issue_comment_url': 'https://api.github.com/repos/cpython/python/issue/1234/comments',
-            'author_association': author_association,
+        "action": action,
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+            "issue_comment_url": "https://api.github.com/repos/cpython/python/issue/1234/comments",
+            "author_association": author_association,
         },
     }
-    await news.check_news(gh, event_data['pull_request'])
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    check_n_pop_nonews_events(gh, author_association == 'NONE')
+    await news.check_news(gh, event_data["pull_request"])
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    check_n_pop_nonews_events(gh, author_association == "NONE")
     assert not gh.post_url
 
 
-@pytest.mark.parametrize('action', ['opened', 'reopened', 'synchronize'])
+@pytest.mark.parametrize("action", ["opened", "reopened", "synchronize"])
 async def test_news_file_not_empty(action):
-    files = [{'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-             {'filename': f'Misc/NEWS.d/next/Library/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +A'}]
-    issue = {'labels': [{'name': 'CLA signed'}]}
+    files = [
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/Library/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +A",
+        },
+    ]
+    issue = {"labels": [{"name": "CLA signed"}]}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
-        'action': action,
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": action,
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await news.check_news(gh, event_data['pull_request'])
-    assert gh.getiter_url == 'https://api.github.com/repos/cpython/python/pulls/1234/files'
-    assert gh.post_url[0] == 'https://api.github.com/some/status'
-    assert gh.post_data[0]['state'] == 'success'
-    assert gh.post_data[0].get('target_url') is None
+    await news.check_news(gh, event_data["pull_request"])
+    assert (
+        gh.getiter_url == "https://api.github.com/repos/cpython/python/pulls/1234/files"
+    )
+    assert gh.post_url[0] == "https://api.github.com/some/status"
+    assert gh.post_data[0]["state"] == "success"
+    assert gh.post_data[0].get("target_url") is None
 
 
 async def test_adding_skip_news_label():
@@ -222,9 +273,9 @@ async def test_adding_skip_news_label():
             "title": "An easy fix",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await news.router.dispatch(event, gh)
-    assert gh.post_data[0]['state'] == 'success'
+    assert gh.post_data[0]["state"] == "success"
 
 
 async def test_adding_benign_label():
@@ -237,7 +288,7 @@ async def test_adding_benign_label():
             "title": "An easy fix",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await news.router.dispatch(event, gh)
     assert len(gh.post_data) == 0
 
@@ -251,35 +302,43 @@ async def test_deleting_label():
             "title": "An easy fix",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await news.router.dispatch(event, gh)
     assert len(gh.post_data) == 0
 
 
-@pytest.mark.parametrize('author_association', ['OWNER', 'MEMBER', 'CONTRIBUTOR', 'NONE'])
+@pytest.mark.parametrize(
+    "author_association", ["OWNER", "MEMBER", "CONTRIBUTOR", "NONE"]
+)
 async def test_removing_skip_news_label(author_association):
     files = [
-        {'filename': 'README', 'patch': '@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.'},
-        {'filename': f'Misc/NEWS.d/next/{GOOD_BASENAME}', 'patch': '@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks'},
-        ]
-    issue = {'labels': []}
+        {
+            "filename": "README",
+            "patch": "@@ -31,3 +31,7 @@ # Licensed to PSF under a Contributor Agreement.",
+        },
+        {
+            "filename": f"Misc/NEWS.d/next/{GOOD_BASENAME}",
+            "patch": "@@ -0,0 +1 @@ +Fix inspect.getsourcelines for module level frames/tracebacks",
+        },
+    ]
+    issue = {"labels": []}
     gh = FakeGH(getiter=files, getitem=issue)
     event_data = {
         "action": "unlabeled",
         "label": {"name": news.SKIP_NEWS_LABEL},
         "number": 1234,
         "pull_request": {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
             "title": "An easy fix",
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
-            'issue_comment_url': 'https://api.github.com/repos/cpython/python/issue/1234/comments',
-            'author_association': author_association,
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
+            "issue_comment_url": "https://api.github.com/repos/cpython/python/issue/1234/comments",
+            "author_association": author_association,
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await news.router.dispatch(event, gh)
-    check_n_pop_nonews_events(gh, author_association == 'NONE')
+    check_n_pop_nonews_events(gh, author_association == "NONE")
     assert not gh.post_url
 
 
@@ -293,6 +352,6 @@ async def test_removing_benign_label():
             "title": "An easy fix",
         },
     }
-    event = sansio.Event(event_data, event='pull_request', delivery_id='1')
+    event = sansio.Event(event_data, event="pull_request", delivery_id="1")
     await news.router.dispatch(event, gh)
     assert len(gh.post_data) == 0

--- a/tests/test_prtype.py
+++ b/tests/test_prtype.py
@@ -3,7 +3,6 @@ from bedevere.prtype import Labels
 
 
 class FakeGH:
-
     def __init__(self, *, getiter=None, getitem=None, post=None):
         self._getitem_return = getitem
         self._getiter_return = getiter
@@ -23,151 +22,151 @@ class FakeGH:
         return self._post_return
 
 
-GOOD_BASENAME = '2017-06-16-20-32-50.bpo-1234.nonce.rst'
-
+GOOD_BASENAME = "2017-06-16-20-32-50.bpo-1234.nonce.rst"
 
 
 async def test_no_files():
     filenames = {}
-    issue = {'labels': []}
+    issue = {"labels": []}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # When no files are present, no labels are added.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 
 
 async def test_news_only():
-    filenames = {'README', f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}'}
-    issue = {'labels': []}
+    filenames = {"README", f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}"}
+    issue = {"labels": []}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # News only .rst does not add a docs label.
     assert len(gh.post_url) == 0
     assert len(gh.post_data) == 0
 
 
 async def test_docs_no_news():
-    filenames = {'path/to/docs1.rst'}
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"path/to/docs1.rst"}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.docs.value, Labels.skip_news.value]
 
 
 async def test_docs_and_news():
-    filenames = {'/path/to/docs1.rst', f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}'}
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"/path/to/docs1.rst", f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}"}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.docs.value]
 
 
 async def test_tests_only():
-    filenames = {'/path/to/test_docs1.py', 'test_docs2.py'}
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"/path/to/test_docs1.py", "test_docs2.py"}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_docs_and_tests():
-    filenames = {'/path/to/docs.rst', 'test_docs2.py'}
-    issue = {'labels': [{'name': 'skip news'}],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"/path/to/docs.rst", "test_docs2.py"}
+    issue = {
+        "labels": [{"name": "skip news"}],
+        "labels_url": "https://api.github.com/some/label",
+    }
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # Only creates type-tests label.
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_leave_existing_type_labels():
-    filenames = {'/path/to/docs.rst', 'test_docs2.py'}
-    issue = {'labels': [{'name': 'skip news'}, {'name': 'docs'}],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"/path/to/docs.rst", "test_docs2.py"}
+    issue = {
+        "labels": [{"name": "skip news"}, {"name": "docs"}],
+        "labels_url": "https://api.github.com/some/label",
+    }
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     assert len(gh.post_url) == 1
     assert gh.post_url[0] == "https://api.github.com/some/label"
     # This should only add the tests label as the docs label is already applied
@@ -175,65 +174,67 @@ async def test_leave_existing_type_labels():
 
 
 async def test_do_not_post_if_nothing_to_apply():
-    filenames = {'/path/to/docs.rst'}
-    issue = {'labels': [{'name': 'skip news'}, {'name': 'docs'}],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"/path/to/docs.rst"}
+    issue = {
+        "labels": [{"name": "skip news"}, {"name": "docs"}],
+        "labels_url": "https://api.github.com/some/label",
+    }
     gh = FakeGH(getiter=filenames, getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # This should not post anything as docs is already applied
     assert len(gh.post_url) == 0
 
 
 async def test_news_and_tests():
-    filenames = {'test_docs2.py', f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}'}
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {"test_docs2.py", f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}"}
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # Creates type-tests label.
     assert len(gh.post_url) == 1
-    assert gh.post_url[0] == 'https://api.github.com/some/label'
+    assert gh.post_url[0] == "https://api.github.com/some/label"
     assert gh.post_data[0] == [Labels.tests.value]
 
 
 async def test_other_files():
-    filenames = {'README', '/path/to/docs.rst', 'test_docs2.py',
-                 f'Misc/NEWS.d/next/Lib/{GOOD_BASENAME}'}
-    issue = {'labels': [],
-             'labels_url': 'https://api.github.com/some/label'}
+    filenames = {
+        "README",
+        "/path/to/docs.rst",
+        "test_docs2.py",
+        f"Misc/NEWS.d/next/Lib/{GOOD_BASENAME}",
+    }
+    issue = {"labels": [], "labels_url": "https://api.github.com/some/label"}
     gh = FakeGH(getitem=issue)
     event_data = {
-        'action': 'opened',
-        'number': 1234,
-        'pull_request': {
-            'url': 'https://api.github.com/repos/cpython/python/pulls/1234',
-            'statuses_url': 'https://api.github.com/some/status',
-            'issue_url': 'https://api.github.com/repos/cpython/python/issue/1234',
+        "action": "opened",
+        "number": 1234,
+        "pull_request": {
+            "url": "https://api.github.com/repos/cpython/python/pulls/1234",
+            "statuses_url": "https://api.github.com/some/status",
+            "issue_url": "https://api.github.com/repos/cpython/python/issue/1234",
         },
     }
-    await prtype.classify_by_filepaths(gh, event_data['pull_request'], filenames)
-    assert gh.getitem_url == 'https://api.github.com/repos/cpython/python/issue/1234'
+    await prtype.classify_by_filepaths(gh, event_data["pull_request"], filenames)
+    assert gh.getitem_url == "https://api.github.com/repos/cpython/python/issue/1234"
     # No labels if a file other than doc or test exists.
     assert len(gh.post_url) == 0
-
-

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -50,7 +50,7 @@ class FakeGH:
 
 async def test_stage():
     # Skip changing labels if the label is already set.
-    issue = {"labels": [{"name": "awaiting merge"}, {"name": "skip issue"}]}
+    issue = {"number": 123, "labels": [{"name": "awaiting merge"}, {"name": "skip issue"}]}
     issue_url = "https://api.github.com/some/issue"
     gh = FakeGH()
     await awaiting.stage(gh, issue, awaiting.Blocker.merge)
@@ -59,6 +59,7 @@ async def test_stage():
 
     # Test deleting an old label and adding a new one.
     issue = {
+        "number": 123,
         "labels": [{"name": "awaiting review"}, {"name": "skip issue"}],
         "labels_url": "https://api.github.com/repos/python/cpython/issues/42/labels{/name}",
     }
@@ -81,6 +82,7 @@ async def test_opened_draft_pr():
     data = {
         "action": "opened",
         "pull_request": {
+            "number": 123,
             "user": {
                 "login": username,
             },
@@ -92,7 +94,7 @@ async def test_opened_draft_pr():
     teams = [{"name": "python core", "id": 6}]
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": "OK",
-        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -118,6 +120,7 @@ async def test_opened_draft_pr():
     data["pull_request"]["draft"] = True
     encoded_label = "awaiting%20core%20review"
     items[issue_url] = {
+        "number": 123,
         "labels": [
             {
                 "url": f"https://api.github.com/repos/python/cpython/labels/{encoded_label}",
@@ -197,6 +200,7 @@ async def test_opened_pr():
     data = {
         "action": "opened",
         "pull_request": {
+            "number": 123,
             "user": {
                 "login": username,
             },
@@ -207,7 +211,7 @@ async def test_opened_pr():
     teams = [{"name": "python core", "id": 6}]
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": "OK",
-        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -224,6 +228,7 @@ async def test_opened_pr():
     data = {
         "action": "opened",
         "pull_request": {
+            "number": 123,
             "user": {
                 "login": username,
             },
@@ -237,7 +242,7 @@ async def test_opened_pr():
         f"https://api.github.com/teams/6/memberships/{username}": gidgethub.BadRequest(
             status_code=http.HTTPStatus(404)
         ),
-        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -261,6 +266,7 @@ async def test_new_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -274,6 +280,7 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -298,6 +305,7 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -322,6 +330,7 @@ async def test_new_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -334,6 +343,7 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -359,6 +369,7 @@ async def test_new_review():
             "state": "APPROVED",
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -369,6 +380,7 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -395,6 +407,7 @@ async def test_new_review():
             "state": "APPROVED",
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "closed",
@@ -405,6 +418,7 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -427,6 +441,7 @@ async def test_new_review():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -441,6 +456,7 @@ async def test_new_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -465,6 +481,7 @@ async def test_new_review():
             "state": "commented".upper(),
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -486,6 +503,7 @@ async def test_new_review():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -496,6 +514,7 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -516,6 +535,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -528,6 +548,7 @@ async def test_dismissed_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.core_review.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -555,6 +576,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -567,6 +589,7 @@ async def test_dismissed_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -591,6 +614,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -605,6 +629,7 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.core_review.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -629,6 +654,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -641,6 +667,7 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -668,6 +695,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -680,6 +708,7 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -707,6 +736,7 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -717,6 +747,7 @@ async def test_dismissed_review():
         f"https://api.github.com/teams/6/memberships/{username}": True,
         f"https://api.github.com/teams/6/memberships/brettcannonalias": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -742,6 +773,7 @@ async def test_non_core_dev_does_not_downgrade():
         ),
         f"https://api.github.com/teams/6/memberships/{core_dev}": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -757,6 +789,7 @@ async def test_non_core_dev_does_not_downgrade():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -786,6 +819,7 @@ async def test_non_core_dev_does_not_downgrade():
             },
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -837,6 +871,7 @@ async def test_new_comment():
     data = {
         "action": "created",
         "issue": {
+            "number": 42,
             "user": {"login": "andreamcinnes"},
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
@@ -886,6 +921,7 @@ async def test_new_comment():
     data = {
         "action": "created",
         "issue": {
+            "number": 42,
             "user": {"login": "andreamcinnes"},
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
@@ -927,6 +963,7 @@ async def test_change_requested_for_core_dev():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -939,6 +976,7 @@ async def test_change_requested_for_core_dev():
         f"https://api.github.com/teams/6/memberships/gvanrossum": True,
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -975,6 +1013,7 @@ async def test_change_requested_for_non_core_dev():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
+            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -989,6 +1028,7 @@ async def test_change_requested_for_non_core_dev():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
+            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -1133,6 +1173,7 @@ async def test_new_commit_pushed_to_approved_pr(issue_url_key, repo_full_name):
             ],
         },
         "https://api.github.com/repos/python/cpython/issues/5547": {
+            "number": 42,
             "labels": [{"name": "awaiting merge"}],
             "labels_url": "https://api.github.com/repos/python/cpython/issues/5547/labels{/name}",
             "pull_request": {

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,11 +1,10 @@
 import http
 
 import gidgethub
-from gidgethub import sansio
 import pytest
+from gidgethub import sansio
 
 from bedevere import stage as awaiting
-
 from bedevere.stage import ACK
 
 
@@ -137,8 +136,8 @@ async def test_opened_draft_pr():
     await awaiting.router.dispatch(event, gh)
     assert len(gh.post_) == 0
     assert (
-        gh.delete_url ==
-        f"https://api.github.com/repos/python/cpython/issues/12345/labels/{encoded_label}"
+        gh.delete_url
+        == f"https://api.github.com/repos/python/cpython/issues/12345/labels/{encoded_label}"
     )
 
 
@@ -159,7 +158,7 @@ async def test_edited_pr_title():
         },
         "changes": {
             "title": "So long and thanks for all the phish",
-        }
+        },
     }
     event = sansio.Event(data, event="pull_request", delivery_id="12345")
     teams = [{"name": "python core", "id": 6}]
@@ -1105,9 +1104,10 @@ async def test_new_commit_pushed_to_approved_pr(issue_url_key, repo_full_name):
     # There is new commit on approved PR
     username = "brettcannon"
     sha = "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9"
-    data = {"commits": [{"id": sha}],
-            "repository": {"full_name": repo_full_name},
-            }
+    data = {
+        "commits": [{"id": sha}],
+        "repository": {"full_name": repo_full_name},
+    }
     event = sansio.Event(data, event="push", delivery_id="12345")
     teams = [{"name": "python core", "id": 6}]
     items = {
@@ -1181,9 +1181,10 @@ async def test_new_commit_pushed_to_approved_pr(issue_url_key, repo_full_name):
 async def test_new_commit_pushed_to_not_approved_pr(issue_url_key, repo_full_name):
     # There is new commit on approved PR
     sha = "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9"
-    data = {"commits": [{"id": sha}],
-            "repository": {"full_name": repo_full_name},
-            }
+    data = {
+        "commits": [{"id": sha}],
+        "repository": {"full_name": repo_full_name},
+    }
     event = sansio.Event(data, event="push", delivery_id="12345")
     items = {
         f"https://api.github.com/search/issues?q=type:pr+repo:{repo_full_name}+sha:{sha}": {

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -50,7 +50,7 @@ class FakeGH:
 
 async def test_stage():
     # Skip changing labels if the label is already set.
-    issue = {"number": 123, "labels": [{"name": "awaiting merge"}, {"name": "skip issue"}]}
+    issue = {"labels": [{"name": "awaiting merge"}, {"name": "skip issue"}]}
     issue_url = "https://api.github.com/some/issue"
     gh = FakeGH()
     await awaiting.stage(gh, issue, awaiting.Blocker.merge)
@@ -59,7 +59,6 @@ async def test_stage():
 
     # Test deleting an old label and adding a new one.
     issue = {
-        "number": 123,
         "labels": [{"name": "awaiting review"}, {"name": "skip issue"}],
         "labels_url": "https://api.github.com/repos/python/cpython/issues/42/labels{/name}",
     }
@@ -82,7 +81,6 @@ async def test_opened_draft_pr():
     data = {
         "action": "opened",
         "pull_request": {
-            "number": 123,
             "user": {
                 "login": username,
             },
@@ -94,7 +92,7 @@ async def test_opened_draft_pr():
     teams = [{"name": "python core", "id": 6}]
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": "OK",
-        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -120,7 +118,6 @@ async def test_opened_draft_pr():
     data["pull_request"]["draft"] = True
     encoded_label = "awaiting%20core%20review"
     items[issue_url] = {
-        "number": 123,
         "labels": [
             {
                 "url": f"https://api.github.com/repos/python/cpython/labels/{encoded_label}",
@@ -200,7 +197,6 @@ async def test_opened_pr():
     data = {
         "action": "opened",
         "pull_request": {
-            "number": 123,
             "user": {
                 "login": username,
             },
@@ -211,7 +207,7 @@ async def test_opened_pr():
     teams = [{"name": "python core", "id": 6}]
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": "OK",
-        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -228,7 +224,6 @@ async def test_opened_pr():
     data = {
         "action": "opened",
         "pull_request": {
-            "number": 123,
             "user": {
                 "login": username,
             },
@@ -242,7 +237,7 @@ async def test_opened_pr():
         f"https://api.github.com/teams/6/memberships/{username}": gidgethub.BadRequest(
             status_code=http.HTTPStatus(404)
         ),
-        issue_url: {"number": 123, "labels": [], "labels_url": "https://api.github.com/labels"},
+        issue_url: {"labels": [], "labels_url": "https://api.github.com/labels"},
     }
     gh = FakeGH(
         getiter={"https://api.github.com/orgs/python/teams": teams}, getitem=items
@@ -266,7 +261,6 @@ async def test_new_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -280,7 +274,6 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -305,7 +298,6 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -330,7 +322,6 @@ async def test_new_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -343,7 +334,6 @@ async def test_new_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -369,7 +359,6 @@ async def test_new_review():
             "state": "APPROVED",
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -380,7 +369,6 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -407,7 +395,6 @@ async def test_new_review():
             "state": "APPROVED",
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "closed",
@@ -418,7 +405,6 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -441,7 +427,6 @@ async def test_new_review():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -456,7 +441,6 @@ async def test_new_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -481,7 +465,6 @@ async def test_new_review():
             "state": "commented".upper(),
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -503,7 +486,6 @@ async def test_new_review():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -514,7 +496,6 @@ async def test_new_review():
     items = {
         f"https://api.github.com/teams/6/memberships/{username}": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.changes.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -535,7 +516,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -548,7 +528,6 @@ async def test_dismissed_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.core_review.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -576,7 +555,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -589,7 +567,6 @@ async def test_dismissed_review():
         ),
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -614,7 +591,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -629,7 +605,6 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.core_review.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -654,7 +629,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -667,7 +641,6 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -695,7 +668,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -708,7 +680,6 @@ async def test_dismissed_review():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -736,7 +707,6 @@ async def test_dismissed_review():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
         },
@@ -747,7 +717,6 @@ async def test_dismissed_review():
         f"https://api.github.com/teams/6/memberships/{username}": True,
         f"https://api.github.com/teams/6/memberships/brettcannonalias": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [{"name": awaiting.Blocker.merge.value}],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -773,7 +742,6 @@ async def test_non_core_dev_does_not_downgrade():
         ),
         f"https://api.github.com/teams/6/memberships/{core_dev}": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -789,7 +757,6 @@ async def test_non_core_dev_does_not_downgrade():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -819,7 +786,6 @@ async def test_non_core_dev_does_not_downgrade():
             },
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "state": "open",
@@ -871,7 +837,6 @@ async def test_new_comment():
     data = {
         "action": "created",
         "issue": {
-            "number": 42,
             "user": {"login": "andreamcinnes"},
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
@@ -921,7 +886,6 @@ async def test_new_comment():
     data = {
         "action": "created",
         "issue": {
-            "number": 42,
             "user": {"login": "andreamcinnes"},
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
@@ -963,7 +927,6 @@ async def test_change_requested_for_core_dev():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -976,7 +939,6 @@ async def test_change_requested_for_core_dev():
         f"https://api.github.com/teams/6/memberships/gvanrossum": True,
         "https://api.github.com/teams/6/memberships/brettcannon": True,
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -1013,7 +975,6 @@ async def test_change_requested_for_non_core_dev():
             "state": "changes_requested".upper(),
         },
         "pull_request": {
-            "number": 42,
             "url": "https://api.github.com/pr/42",
             "issue_url": "https://api.github.com/issue/42",
             "comments_url": "https://api.github.com/comment/42",
@@ -1028,7 +989,6 @@ async def test_change_requested_for_non_core_dev():
             status_code=http.HTTPStatus(404)
         ),
         "https://api.github.com/issue/42": {
-            "number": 42,
             "labels": [],
             "labels_url": "https://api.github.com/labels/42",
         },
@@ -1173,7 +1133,6 @@ async def test_new_commit_pushed_to_approved_pr(issue_url_key, repo_full_name):
             ],
         },
         "https://api.github.com/repos/python/cpython/issues/5547": {
-            "number": 42,
             "labels": [{"name": "awaiting merge"}],
             "labels_url": "https://api.github.com/repos/python/cpython/issues/5547/labels{/name}",
             "pull_request": {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,8 @@
 import http
+from unittest.mock import patch
 
 import gidgethub
 import pytest
-from unittest.mock import patch
 
 from bedevere import util
 
@@ -99,10 +99,13 @@ async def test_is_core_dev():
 
 
 async def test_is_core_dev_resource_not_accessible():
-
-    gh = FakeGH(getiter={"https://api.github.com/orgs/python/teams": [gidgethub.BadRequest(
-            status_code=http.HTTPStatus(403)
-        )]})
+    gh = FakeGH(
+        getiter={
+            "https://api.github.com/orgs/python/teams": [
+                gidgethub.BadRequest(status_code=http.HTTPStatus(403))
+            ]
+        }
+    )
     assert await util.is_core_dev(gh, "mariatta") is False
 
 
@@ -208,7 +211,9 @@ async def test_patch_body_adds_issue_if_not_present():
     with patch.object(gh, "patch") as mock:
         vals["body"] = ""
         await util.patch_body(gh, util.PR, vals, 1234)
-        data = {"body": "\n\n<!-- gh-issue-number: gh-1234 -->\n* Issue: gh-1234\n<!-- /gh-issue-number -->\n"}
+        data = {
+            "body": "\n\n<!-- gh-issue-number: gh-1234 -->\n* Issue: gh-1234\n<!-- /gh-issue-number -->\n"
+        }
         mock.assert_called_once_with("https://fake.com", data=data)
     assert await gh.patch(vals["url"], data=vals) == None
 


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `d354adb..a5ec2ba`
**Files Changed:** 23 (18 programming files)
**Programming Ratio:** 78.3%

**Commits included:**
- Bump yarl from 1.9.2 to 1.9.3 (#610)
- Bump sentry-sdk from 1.33.1 to 1.38.0 (#609)
- Bump aiohttp from 3.9.0 to 3.9.1 (#608)
- Bump aiohttp from 3.9.0b0 to 3.9.0 (#607)
- Bump packaging from 23.1 to 23.2 (#600)
- Bump cachetools from 5.3.1 to 5.3.2 (#601)
- Bump sentry-sdk from 1.31.0 to 1.33.1 (#602)
- Bump pytest from 7.4.2 to 7.4.3 (#603)
- Merge pull request #596 from pradyunsg/lint-and-format
- Ignore the reformatting commit in `git blame`
... and 5 more commits